### PR TITLE
fix: the "caption" should place behind the tag of "example"

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -91,7 +91,7 @@ export const getParser = (parser: any) =>
               tag = TAGS_SYNONYMS[tag as keyof typeof TAGS_SYNONYMS];
             }
             const isVerticallyAlignAbleTags = TAGS_VERTICALLY_ALIGN_ABLE.includes(
-              tag
+              tag,
             );
 
             if (TAGS_NAMELESS.includes(tag) && name) {
@@ -112,7 +112,7 @@ export const getParser = (parser: any) =>
               if (isVerticallyAlignAbleTags)
                 maxTagTypeNameLength = Math.max(
                   maxTagTypeNameLength,
-                  type.length
+                  type.length,
                 );
 
               // Additional operations on name
@@ -138,7 +138,7 @@ export const getParser = (parser: any) =>
             description = formatDescription(
               tag,
               description,
-              options.jsdocDescriptionWithDot
+              options.jsdocDescriptionWithDot,
             );
 
             return {
@@ -151,7 +151,7 @@ export const getParser = (parser: any) =>
               default: _default,
               optional,
             };
-          }
+          },
         )
 
         // Sort tags
@@ -172,7 +172,7 @@ export const getParser = (parser: any) =>
             comment,
             maxTagTitleLength,
             maxTagTypeNameLength,
-            maxTagNameLength
+            maxTagNameLength,
           );
         });
 

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -119,12 +119,12 @@ const stringify = (
   // Try to use prettier on @example tag description
   if (tag === EXAMPLE) {
     const exampleCaption = description.match(
-      /<caption>([\s\S]*)<\/caption>/i,
-    )?.[0];
+      /<caption>(((?!(<\/caption>))[\s\S])*)<\/caption>/i,
+    );
 
-    if (tagString.endsWith("example") && exampleCaption) {
-      description = description.replace(exampleCaption, "");
-      tagString = `${tagString} ${exampleCaption}`;
+    if (exampleCaption) {
+      description = description.replace(exampleCaption[0], "");
+      tagString = `${tagString} ${exampleCaption[0]}`;
     }
 
     try {

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -18,7 +18,7 @@ const stringify = (
   comment: PrettierComment,
   maxTagTitleLength: number,
   maxTagTypeNameLength: number,
-  maxTagNameLength: number
+  maxTagNameLength: number,
 ): string => {
   const {
     loc: {
@@ -127,7 +127,8 @@ const stringify = (
       tagString += description
         .split("\n")
         .map(
-          (l) => `  ${options.jsdocKeepUnParseAbleExampleIndent ? l : l.trim()}`
+          (l) =>
+            `  ${options.jsdocKeepUnParseAbleExampleIndent ? l : l.trim()}`,
         )
         .join("\n");
     }

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -118,6 +118,15 @@ const stringify = (
 
   // Try to use prettier on @example tag description
   if (tag === EXAMPLE) {
+    const exampleCaption = description.match(
+      /<caption>([\s\S]*)<\/caption>/i,
+    )?.[0];
+
+    if (tagString.endsWith("example") && exampleCaption) {
+      description = description.replace(exampleCaption, "");
+      tagString = `${tagString} ${exampleCaption}`;
+    }
+
     try {
       const formattedExample = format(description || "", options);
       tagString += formattedExample.replace(/(^|\n)/g, "\n  ");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,7 @@ function numberOfAStringInString(string: string, search: string | RegExp) {
 function formatDescription(
   tag: string,
   text: string,
-  insertDot: boolean
+  insertDot: boolean,
 ): string {
   text = text || "";
   text = text.trim();
@@ -116,7 +116,7 @@ function formatDescription(
 
   text = text.replace(
     /(\n\n\s\s\s+)|(\n\s+\n\s\s\s+)/g,
-    NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE
+    NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE,
   ); // Add a signature for new paragraph start with three space
   text = text.replace(/(\n\n)|(\n\s+\n)/g, EMPTY_LINE_SIGNATURE); // Add a signature for empty line and use that later
   text = text.replace(/\n\s\s\s+/g, NEW_LINE_START_THREE_SPACE_SIGNATURE); // Add a signature for new line start with three space

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -32,8 +32,7 @@ exports[`Big single word 1`] = `
 
 exports[`Example start by xml tag 1`] = `
 "/**
- * @example
- *   <caption>TradingViewChart</caption>;
+ * @example <caption>TradingViewChart</caption>
  *   export default Something;
  */
 "

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -38,6 +38,17 @@ exports[`Example start by xml tag 1`] = `
 "
 `;
 
+exports[`Example start by xml tag 2`] = `
+"/**
+ * @example <caption>TradingViewChart</caption>
+ *   function Something() {
+ *     return <caption>TradingViewChart</caption>;
+ *   }
+ *   export default Something;
+ */
+"
+`;
+
 exports[`Hyphen at the start of description 1`] = `
 "/**
  * Assign the project to an employee.

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -169,7 +169,7 @@ test("Should align vertically param|property|returns|yields|throws if option set
  * @yields {Number} yields description
  * @returns {undefined}
  */`,
-    options
+    options,
   );
   const Expected1 = `/**
  * @property {Object}    unalginedProp  Unaligned property descriptin
@@ -185,7 +185,7 @@ test("Should align vertically param|property|returns|yields|throws if option set
  * @yields {Number} yields description
  * @return {String} unaligned returns description
  */`,
-    options
+    options,
   );
   const Expected2 = `/**
  * @throws  {CustomExceptio} Unaligned throws description
@@ -224,7 +224,7 @@ test("Should align vertically param|property|returns|yields|throws if option set
  * @yields {Number} yields description
  * @returns {String} unaligned returns description
  */`,
-    options2
+    options2,
   );
 
   expect(Result1).toMatchSnapshot();
@@ -240,7 +240,7 @@ test("Should insert proper amount of spaces based on option", () => {
  * @param {Object} paramName param description that goes on and on and on utill it will need to be wrapped
  * @returns {Number} return description
  */`,
-    options1
+    options1,
   );
 
   const options2 = {
@@ -251,7 +251,7 @@ test("Should insert proper amount of spaces based on option", () => {
  * @param {Object} paramName param description that goes on and on and on utill it will need to be wrapped
  * @returns {Number} return description
  */`,
-    options2
+    options2,
   );
 
   expect(Result1).toMatchSnapshot();
@@ -266,35 +266,35 @@ test("yields should work like returns tag", () => {
     `/**
  * @yields {Number} yields description
  */`,
-    options
+    options,
   );
 
   const Result2 = subject(
     `/**
  * @yield {Number} yields description
  */`,
-    options
+    options,
   );
 
   const Result3 = subject(
     `/**
  * @yield {Number}
  */`,
-    options
+    options,
   );
 
   const Result4 = subject(
     `/**
  * @yield yelds description
  */`,
-    options
+    options,
   );
 
   const Result5 = subject(
     `/**
  * @yield
  */`,
-    options
+    options,
   );
 
   expect(Result1).toMatchSnapshot();
@@ -317,7 +317,7 @@ test("examples", () => {
  *   ]
  *  }
  */`,
-    options
+    options,
   );
 
   const Result2 = subject(
@@ -333,7 +333,7 @@ test("examples", () => {
  *   bar: 5
  * }]
  */`,
-    options
+    options,
   );
   expect(Result1).toMatchSnapshot();
   expect(Result2).toMatchSnapshot();
@@ -344,7 +344,7 @@ test("Big single word", () => {
     `/**
     * Simple Single Word
     * https://github.com/babel/babel/pull/7934/files#diff-a739835084910b0ee3ea649df5a4d223R67
-   */`
+   */`,
   );
 
   expect(result).toMatchSnapshot();
@@ -367,12 +367,25 @@ test("Example start by xml tag", () => {
   const result = subject(`
   /**
    * @example <caption>TradingViewChart</caption>;
-   *
+   * 
    * export default Something
    */
 `);
 
   expect(result).toMatchSnapshot();
+
+  const result1 = subject(`
+  /**
+   * @example <caption>TradingViewChart</caption>
+   *
+   * function Something(){
+   *   return <caption>TradingViewChart</caption>
+   * }
+   * export default Something
+   */
+`);
+
+  expect(result1).toMatchSnapshot();
 });
 
 test("Bad defined name", () => {


### PR DESCRIPTION
before

```tsx
/**
 * @example
 *   ;<caption>A Script that can fetch the new data</caption>
 *
 *   const remoteSupportSymbols = await fetch(URL).then(res => res.json())
 *
 *   globalThis.foo = keyBy(
 *     remoteSupportSymbols.filter(value => value.type !== 'option').map(value => camelizeKeys(value)),
 *     'symbol',
 *   )
 *
 *   console.info(globalThis.foo)
 */
```

with this PR

```tsx
/**
 * @example <caption>A Script that can fetch the new data</caption>
 *
 *   const remoteSupportSymbols = await fetch(URL).then(res => res.json())
 *
 *   globalThis.foo = keyBy(
 *     remoteSupportSymbols.filter(value => value.type !== 'option').map(value => camelizeKeys(value)),
 *     'symbol',
 *   )
 *
 *   console.info(globalThis.foo)
 */
```