### PR TITLE
fix: keep empty line comments

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -193,7 +193,10 @@ export const getParser = (parser: any) =>
       }
     });
 
-    ast.comments = ast.comments.filter(({ value }) => value);
+    ast.comments = ast.comments.filter(
+      ({ type, value }) =>
+        (type !== "CommentBlock" && type !== "Block") || value,
+    );
 
     return ast;
   };

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -30,6 +30,12 @@ exports[`Big single word 1`] = `
 "
 `;
 
+exports[`Empty comment 1`] = `
+"// Line Comment
+//
+"
+`;
+
 exports[`Hyphen at the start of description 1`] = `
 "/**
  * Assign the project to an employee.

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -379,3 +379,12 @@ test("Incorrect comment", () => {
   expect(result).toMatchSnapshot();
   expect(result2).toMatchSnapshot();
 });
+
+test("Empty comment", () => {
+  const result = subject(`
+  // Line Comment
+  //
+  `);
+
+  expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
I noticed that this plugin's latest release has been deleting empty line comments. Fix, with unit test. The unit test does fail if the fix isn't applied.