### PR TITLE
Updated incorrect default in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Description is formatting as Markdown, so you could use any features of Markdown
 | jsdocDescriptionWithDot           | Boolean | false   |
 | jsdocDescriptionTag               | Boolean | false   |
 | jsdocVerticalAlignment            | Boolean | false   |
-| jsdocKeepUnParseAbleExampleIndent | Boolean | true    |
+| jsdocKeepUnParseAbleExampleIndent | Boolean | false   |
 
 Full up to date list and description of options can be found in Prettier help. First install plugin then run Prettier with "--help" option.
 


### PR DESCRIPTION
The default value of `jsdocKeepUnParseAbleExampleIndent` was incorrect. The correct value according to the CLI is:

```
  --jsdoc-keep-un-parse-able-example-indent
                           Should unParseAble example (pseudo code or no js code) keep its indentation
                           Defaults to false.
```