### PR TITLE
fix(parser): modern array transformation

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import commentParser from "comment-parser";
 import {
   addStarsToTheBeginningOfTheLines,
-  convertToModernArray,
+  convertToModernType,
   formatType,
 } from "./utils";
 import { DESCRIPTION } from "./tags";
@@ -120,7 +120,7 @@ export const getParser = (parser: any) =>
                 optional = true;
               }
 
-              type = convertToModernArray(type);
+              type = convertToModernType(type);
               type = formatType(type, options);
 
               if (isVerticallyAlignAbleTags)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,10 +8,17 @@ function convertToModernType(oldType: string): string {
     type = type.replace(/\*/g, " any ");
 
     // convert `Array<Foo>` to `Foo[]`
-    type = type.replace(
-      /(?:^|[^$\w\xA0-\uFFFF])Array\s*<((?:[^<>=]|=>|=(?!>)|<(?:[^<>=]|=>|=(?!>))+>)+)>/g,
-      "($1)[]",
-    );
+    let changed = true;
+    while (changed) {
+      changed = false;
+      type = type.replace(
+        /(^|[^$\w\xA0-\uFFFF])Array\s*<((?:[^<>=]|=>|=(?!>)|<(?:[^<>=]|=>|=(?!>))+>)+)>/g,
+        (_, prefix, inner) => {
+          changed = true;
+          return `${prefix}(${inner})[]`;
+        },
+      );
+    }
 
     return type;
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,8 @@ function convertToModernType(oldType: string): string {
     // JSDoc supports generics of the form `Foo.<Arg1, Arg2>`
     type = type.replace(/\.</g, "<");
 
+    type = type.replace(/\*/g, " any ");
+
     // convert `Array<Foo>` to `Foo[]`
     type = type.replace(
       /(?:^|[^$\w\xA0-\uFFFF])Array\s*<((?:[^<>=]|=>|=(?!>)|<(?:[^<>=]|=>|=(?!>))+>)+)>/g,
@@ -51,10 +53,9 @@ function withoutStrings(type: string, mapFn: (type: string) => string): string {
 
 function formatType(type: string, options?: Options): string {
   try {
-    let pretty = type.replace("*", "any");
     const TYPE_START = "type name = ";
 
-    pretty = format(`${TYPE_START}${pretty}`, {
+    let pretty = format(`${TYPE_START}${type}`, {
       ...options,
       parser: "typescript",
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,8 @@ function convertToModernType(oldType: string): string {
 function withoutStrings(type: string, mapFn: (type: string) => string): string {
   const strings: string[] = [];
   let modifiedType = type.replace(
+    // copied from Prism's C-like language that is used to tokenize JS strings
+    // https://github.com/PrismJS/prism/blob/266cc7002e54dae674817ab06a02c2c15ed64a6f/components/prism-clike.js#L15
     /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/g,
     (m) => {
       strings.push(m);

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -269,6 +269,7 @@ exports[`Sould keep params ordering when more than 10 tags are present 1`] = `
  * @param {?undefined} test4 Test param
  * @param {!undefined} test5 Test param
  * @param {any} test6 Test param
+ * @param {\\"*\\"} test6 Test param
  * @param {?Number} test7 Test param
  * @param {...Number} test8 Test param
  * @param {!Number} test9 Test param

--- a/tests/__snapshots__/modern.test.js.snap
+++ b/tests/__snapshots__/modern.test.js.snap
@@ -12,6 +12,7 @@ exports[`convert array to modern type 1`] = `
  * @param {((item: Foo<Bar>) => Bar<number>)[] | number[] | string[]} arg2
  * @param {((item: Foo<Bar>) => Bar<number>)[] | number[] | \\"Foo.<>\\"[]} arg3
  * @param {\\"Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>\\"} arg4
+ * @param {number[][][]} arg5
  */
 function a() {}
 "

--- a/tests/__snapshots__/modern.test.js.snap
+++ b/tests/__snapshots__/modern.test.js.snap
@@ -8,6 +8,10 @@ exports[`convert array to modern type 1`] = `
  * @param {ReadonlyArray<Adaptable>} InterpolationConfig.inputRange Like [0,1]
  * @param {string[]} InterpolationConfig.outputRange Like [\\"#0000ff\\",\\"#ff0000\\"]
  * @param {import(\\"react-native-reanimated\\").default.Extrapolate} [InterpolationConfig.extrapolate]
+ * @param {Foo<Bar>[]} arg1
+ * @param {((item: Foo<Bar>) => Bar<number>)[] | number[] | string[]} arg2
+ * @param {((item: Foo<Bar>) => Bar<number>)[] | number[] | \\"Foo.<>\\"[]} arg3
+ * @param {\\"Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>\\"} arg4
  */
 function a() {}
 "

--- a/tests/__snapshots__/modern.test.js.snap
+++ b/tests/__snapshots__/modern.test.js.snap
@@ -13,6 +13,7 @@ exports[`convert array to modern type 1`] = `
  * @param {((item: Foo<Bar>) => Bar<number>)[] | number[] | \\"Foo.<>\\"[]} arg3
  * @param {\\"Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>\\"} arg4
  * @param {number[][][]} arg5
+ * @param {{ foo: number[]; bar: string[] }} arg6
  */
 function a() {}
 "

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -124,6 +124,7 @@ test("Sould keep params ordering when more than 10 tags are present", () => {
  * @param {?undefined} test4 Test param
  * @param {!undefined} test5 Test param
  * @param {*} test6 Test param
+ * @param {"*"} test6 Test param
  * @param {?Number} test7 Test param
  * @param {...Number} test8 Test param
  * @param {!Number} test9 Test param

--- a/tests/modern.test.js
+++ b/tests/modern.test.js
@@ -18,6 +18,10 @@ test("convert array to modern type", () => {
    * @param {ReadonlyArray<Adaptable>} InterpolationConfig.inputRange Like [0,1]
    * @param {Array<string>} InterpolationConfig.outputRange Like ["#0000ff","#ff0000"]
    * @param {import("react-native-reanimated").default.Extrapolate} [InterpolationConfig.extrapolate]
+   * @param {Array<Foo<Bar>>} arg1
+   * @param {Array<(item: Foo<Bar>) => Bar<number>> | Array<number> | Array<string>} arg2
+   * @param {Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>} arg3
+   * @param {"Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>"} arg4
    *
    */
   function a(){}

--- a/tests/modern.test.js
+++ b/tests/modern.test.js
@@ -22,6 +22,7 @@ test("convert array to modern type", () => {
    * @param {Array<(item: Foo<Bar>) => Bar<number>> | Array<number> | Array<string>} arg2
    * @param {Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>} arg3
    * @param {"Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>"} arg4
+   * @param {Array<Array<Array<number>>>} arg5
    *
    */
   function a(){}

--- a/tests/modern.test.js
+++ b/tests/modern.test.js
@@ -23,6 +23,7 @@ test("convert array to modern type", () => {
    * @param {Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>} arg3
    * @param {"Array.<(item: Foo.<Bar>) => Bar.<number>> | Array.<number> | Array.<'Foo.<>'>"} arg4
    * @param {Array<Array<Array<number>>>} arg5
+   * @param {{ foo: Array<number>; bar: Array<string> }} arg6
    *
    */
   function a(){}


### PR DESCRIPTION
Changes:

- The function is now called `convertToModernType` instead of `convertToModernArray`. This is appropriate because it also converts JSDoc-type generics (`Foo.<Bar>`) to TS generics (`Foo<Bar>`).
- String literals are now accounted for. This means that they are now guaranteed to be unaffected by transformations. Template literal types are not supported, however. If template literal types are detected, the function will immediately return without changing the type as correctness cannot be guaranteed.
- The regex that replaces arrays now supports up to one level of nested generics. E.g. `Array<Foo>` and `Array<Foo<Bar>>` are supported but `Array<Foo<Foo<Bar>>>` is not.