### PR TITLE
fix(parser): jsdoc check

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -54,7 +54,7 @@ export const getParser = (parser: any) =>
        * Check if this comment block is a JSDoc. Based on:
        * https://github.com/jsdoc/jsdoc/blob/master/packages/jsdoc/plugins/commentsOnly.js
        */
-      if (!commentString.match(/\/\*\*[\s\S]+?\*\//g)) return;
+      if (!/^\/\*\*[\s\S]+?\*\/$/.test(commentString)) return;
 
       const parsed = commentParser(commentString, {
         dotted_names: false,

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -93,6 +93,13 @@ exports[`Long description memory leak 1`] = `
 "
 `;
 
+exports[`Non-jsdoc comment 1`] = `
+"// @type   { something  }
+/* @type   { something  }  */
+/* /** @type   { something  }  */
+"
+`;
+
 exports[`Should align vertically param|property|returns|yields|throws if option set to true, and amount of spaces is different than default 1`] = `
 "/**
  * @property  {Object}          unalginedProp   Unaligned property descriptin

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -388,3 +388,13 @@ test("Empty comment", () => {
 
   expect(result).toMatchSnapshot();
 });
+
+test("Non-jsdoc comment", () => {
+  const result = subject(`
+  // @type   { something  }
+  /* @type   { something  }  */
+  /* /** @type   { something  }  */
+  `);
+
+  expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
The JSDoc check had false positives.

The comment `/* foo /** something */` also passed the check.