### PR TITLE
refactor: better types for parser

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -166,7 +166,7 @@ export const getParser = (parser: Parser["parse"]) =>
               source,
               default: _default,
               optional,
-            };
+            } as commentParser.Tag;
           },
         )
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -17,10 +17,15 @@ import {
 import { AST, JsdocOptions } from "./types";
 import { stringify } from "./stringify";
 import { convertCommentDescToDescTag } from "./descriptionFormatter";
+import { Parser } from "prettier";
 
 /** @link https://prettier.io/docs/en/api.html#custom-parser-api} */
-export const getParser = (parser: any) =>
-  function jsdocParser(text: string, parsers: any, options: JsdocOptions): AST {
+export const getParser = (parser: Parser["parse"]) =>
+  function jsdocParser(
+    text: string,
+    parsers: Parameters<Parser["parse"]>[1],
+    options: JsdocOptions,
+  ): AST {
     const ast = parser(text, parsers, options) as AST;
 
     if (!options.jsdocParser) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Options } from "prettier";
+import { ParserOptions } from "prettier";
 
 export type JsdocOptions = {
   jsdocSpaces: number;
@@ -7,7 +7,7 @@ export type JsdocOptions = {
   jsdocVerticalAlignment: boolean;
   jsdocKeepUnParseAbleExampleIndent: boolean;
   jsdocParser: boolean;
-} & Options;
+} & ParserOptions;
 
 type LocationDetails = { line: number; column: number };
 type Location = { start: LocationDetails; end: LocationDetails };


### PR DESCRIPTION
I wanted to get rid of the `parser: any`, so I did. As it turned out, `JsdocOptions` extended the wrong option type.