### PR TITLE
fix(parser): tag type correction

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -89,8 +89,8 @@ export const getParser = (parser: any) =>
           }) => {
             /** When space between tag and type missed */
             const tagSticksToType = tag.indexOf("{");
-            if (tagSticksToType !== -1) {
-              type = tag.slice(tagSticksToType + 1, tag.indexOf("}"));
+            if (tagSticksToType !== -1 && tag[tag.length - 1] === "}") {
+              type = tag.slice(tagSticksToType + 1, -1);
               tag = tag.slice(0, tagSticksToType);
             }
 

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -17,6 +17,7 @@ exports[` undefined|null|void type 3`] = `
 
 exports[`Bad defined name 1`] = `
 "/** @type {import(\\"@jest/types/build/Config\\").InitialOptions} */
+/** @type {{ foo: string }} */
 
 /** @typedef {import(\\"@jest/types/build/Config\\").InitialOptions} name A description */
 "

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -41,7 +41,7 @@ test("Should format regular jsDoc", () => {
 *   var two = 10
 *
 *   if(one > 2) { two += one }
-* @undefiendTag 
+* @undefiendTag${" "}
 * @undefiendTag {number} name des
 */
 const testFunction = (text, defaultValue, optionalNumber) => true
@@ -79,7 +79,7 @@ test(" undefined|null|void type", () => {
  */`);
 
   const Result3 = subject(`/**
- * @returns { void }
+ * @returns { void }${" "}
  */`);
 
   expect(Result1).toMatchSnapshot();

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -79,7 +79,7 @@ test(" undefined|null|void type", () => {
  */`);
 
   const Result3 = subject(`/**
- * @returns { void } 
+ * @returns { void }
  */`);
 
   expect(Result1).toMatchSnapshot();
@@ -330,6 +330,7 @@ test("Hyphen at the start of description", () => {
 test("Bad defined name", () => {
   const result = subject(`
   /** @type{import('@jest/types/build/Config').InitialOptions} */
+  /** @type{{foo:string}} */
 
   /** @typedef{import('@jest/types/build/Config').InitialOptions} name a description  */
 `);


### PR DESCRIPTION
I noticed that the tag type correction could potentially discard part of the "tag".