### PR TITLE
fix(parser): optional parameter types

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -114,11 +114,14 @@ export const getParser = (parser: any) =>
             }
 
             if (type) {
-              /** Convert optional to standard */
-              if (/[?]$/g.test(type)) {
-                type = type.replace(/[?]$/g, "");
+              /**
+               * Convert optional to standard
+               * https://jsdoc.app/tags-type.html#:~:text=Optional%20parameter
+               */
+              type = type.replace(/[=]$/, () => {
                 optional = true;
-              }
+                return "";
+              });
 
               type = convertToModernArray(type);
               type = formatType(type, options);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,20 @@ import { format, Options } from "prettier";
 
 function convertToModernType(oldType: string): string {
   return withoutStrings(oldType, (type) => {
+    type = type.trim();
+
     // JSDoc supports generics of the form `Foo.<Arg1, Arg2>`
     type = type.replace(/\.</g, "<");
 
+    // JSDoc supports `*` to match any type
     type = type.replace(/\*/g, " any ");
+
+    // JSDoc supports `?` (prefix or suffix) to make a type nullable
+    // This is only a limited approximation because the full solution requires
+    // a full TS parser.
+    type = type
+      .replace(/^\?\s*(\w+)$/, "$1 | null")
+      .replace(/^(\w+)\s*\?$/, "$1 | null");
 
     // convert `Array<Foo>` to `Foo[]`
     let changed = true;

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -93,6 +93,15 @@ exports[`Long description memory leak 1`] = `
 "
 `;
 
+exports[`Optional parameters 1`] = `
+"/**
+ * @param {number} [arg1]
+ * @param {number} [arg2]
+ * @param {number} [arg3] Default is \`4\`
+ */
+"
+`;
+
 exports[`Should align vertically param|property|returns|yields|throws if option set to true, and amount of spaces is different than default 1`] = `
 "/**
  * @property  {Object}          unalginedProp   Unaligned property descriptin

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -281,8 +281,8 @@ exports[`Sould keep complex inner types 1`] = `
  * @param {(String | Number)[]} test Test param
  * @param {Object<String, Number>[]} test Test param
  * @param {...Number} test Test param
- * @param {?Number} test Test param
- * @param {?undefined} test Test param
+ * @param {Number | null} test Test param
+ * @param {undefined | null} test Test param
  * @param {!Number} test Test param
  * @param {Number} test Test param
  * @param {Number | String} test Test param
@@ -305,11 +305,11 @@ exports[`Sould keep params ordering when more than 10 tags are present 1`] = `
  * @param {Number} test1 Test param
  * @param {Number} test2 Test param
  * @param {Number | String} test3 Test param
- * @param {?undefined} test4 Test param
+ * @param {undefined | null} test4 Test param
  * @param {!undefined} test5 Test param
  * @param {any} test6 Test param
  * @param {\\"*\\"} test6 Test param
- * @param {?Number} test7 Test param
+ * @param {Number | null} test7 Test param
  * @param {...Number} test8 Test param
  * @param {!Number} test9 Test param
  * @param {String} test10 Test param

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -388,3 +388,15 @@ test("Empty comment", () => {
 
   expect(result).toMatchSnapshot();
 });
+
+test("Optional parameters", () => {
+  const result = subject(`
+  /**
+   * @param {number=} arg1
+   * @param {number} [arg2]
+   * @param {number} [arg3=4]
+   */
+  `);
+
+  expect(result).toMatchSnapshot();
+});

--- a/tests/prettierSource/__snapshots__/index.test.js.snap
+++ b/tests/prettierSource/__snapshots__/index.test.js.snap
@@ -8,8 +8,8 @@ const ignore = require(\\"ignore\\");
 const getFileContentOrNull = require(\\"../utils/get-file-content-or-null\\");
 
 /**
- * @param {string} [ignorePath]
- * @param {boolean} [withNodeModules]
+ * @param {?string} ignorePath
+ * @param {?boolean} withNodeModules
  */
 async function createIgnorer(ignorePath, withNodeModules) {
   const ignoreContent = ignorePath
@@ -20,8 +20,8 @@ async function createIgnorer(ignorePath, withNodeModules) {
 }
 
 /**
- * @param {string} [ignorePath]
- * @param {boolean} [withNodeModules]
+ * @param {?string} ignorePath
+ * @param {?boolean} withNodeModules
  */
 createIgnorer.sync = function (ignorePath, withNodeModules) {
   const ignoreContent = !ignorePath
@@ -32,7 +32,7 @@ createIgnorer.sync = function (ignorePath, withNodeModules) {
 
 /**
  * @param {null | string} ignoreContent
- * @param {boolean} [withNodeModules]
+ * @param {?boolean} withNodeModules
  */
 function _createIgnorer(ignoreContent, withNodeModules) {
   const ignorer = ignore().add(ignoreContent || \\"\\");

--- a/tests/prettierSource/__snapshots__/index.test.js.snap
+++ b/tests/prettierSource/__snapshots__/index.test.js.snap
@@ -8,8 +8,8 @@ const ignore = require(\\"ignore\\");
 const getFileContentOrNull = require(\\"../utils/get-file-content-or-null\\");
 
 /**
- * @param {?string} ignorePath
- * @param {?boolean} withNodeModules
+ * @param {string | null} ignorePath
+ * @param {boolean | null} withNodeModules
  */
 async function createIgnorer(ignorePath, withNodeModules) {
   const ignoreContent = ignorePath
@@ -20,8 +20,8 @@ async function createIgnorer(ignorePath, withNodeModules) {
 }
 
 /**
- * @param {?string} ignorePath
- * @param {?boolean} withNodeModules
+ * @param {string | null} ignorePath
+ * @param {boolean | null} withNodeModules
  */
 createIgnorer.sync = function (ignorePath, withNodeModules) {
   const ignoreContent = !ignorePath
@@ -32,7 +32,7 @@ createIgnorer.sync = function (ignorePath, withNodeModules) {
 
 /**
  * @param {null | string} ignoreContent
- * @param {?boolean} withNodeModules
+ * @param {boolean | null} withNodeModules
  */
 function _createIgnorer(ignoreContent, withNodeModules) {
   const ignorer = ignore().add(ignoreContent || \\"\\");


### PR DESCRIPTION
The syntax for nullable types (e.g `number?` == `?number` == `number | null`) was parsed as the syntax for [optional parameters](https://jsdoc.app/tags-type.html#:~:text=Optional%20parameter) (e.g. `@param {number=} foo` == `@param {number} [foo]`).

### Further proof:

```js
/**
 * @param {null | string} ignoreContent
 * @param {boolean?} withNodeModules
 */
function _createIgnorer(ignoreContent, withNodeModules) {}
```
![image](https://user-images.githubusercontent.com/20878432/106486724-3d47bd00-64b2-11eb-8926-66488ee9e11d.png)

---

```js
/**
 * @param {null | string} ignoreContent
 * @param {boolean=} withNodeModules
 */
function _createIgnorer(ignoreContent, withNodeModules) {}
```
![image](https://user-images.githubusercontent.com/20878432/106486758-459ff800-64b2-11eb-9390-2318918d834a.png)
