### PR TITLE
fix: formatting

### DIFF
--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -1,40 +1,15 @@
-import { format } from "prettier";
-import { TAGS_NEED_FORMAT_DESCRIPTION } from "./roles";
-import { DESCRIPTION, EXAMPLE, TODO } from "./tags";
+import { DESCRIPTION } from "./tags";
 import { Comment } from "comment-parser";
 import { JsdocOptions } from "./types";
-import { capitalizer } from "./utils";
+import {
+  capitalizer,
+  trimEmptyLines,
+  trimTrailingSpaces,
+  tryFormat,
+} from "./utils";
 
-const EMPTY_LINE_SIGNATURE = "2@^5!~#sdE!_EMPTY_LINE_SIGNATURE";
-const NEW_LINE_START_WITH_DASH = "2@^5!~#sdE!_NEW_LINE_START_WITH_DASH";
-const NEW_DASH_LINE = "2@^5!~#sdE!_NEW_LINE_WITH_DASH";
-const NEW_LINE_START_WITH_NUMBER = "2@^5!~#sdE!_NEW_LINE_START_WITH_NUMBER";
-const NEW_PARAGRAPH_START_WITH_DASH =
-  "2@^5!~#sdE!_NEW_PARAGRAPH_START_WITH_DASH";
-const NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE =
-  "2@^5!~#sdE!_NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE";
-const CODE = "2@^5!~#sdE!_CODE";
-
-interface DescriptionEndLineParams {
-  description: string;
-  tag: string;
-  isEndTag: boolean;
-}
-
-function descriptionEndLine({
-  description,
-  tag,
-  isEndTag,
-}: DescriptionEndLineParams): string {
-  if (description.trim().length < 0 || isEndTag) {
-    return "";
-  }
-
-  if ([DESCRIPTION, EXAMPLE, TODO].includes(tag)) {
-    return "\n";
-  }
-
-  return "";
+interface FormatOptions {
+  firstLinePrintWidth?: number;
 }
 
 /**
@@ -42,207 +17,62 @@ function descriptionEndLine({
  * set to true and last character is a word character
  *
  * @private
- * @param {Boolean} insertDot Flag for dot at the end of text
  */
 function formatDescription(
-  tag: string,
   text: string,
-  tagString: string,
-  column: number,
   options: JsdocOptions,
+  formatOptions?: FormatOptions,
 ): string {
-  if (!TAGS_NEED_FORMAT_DESCRIPTION.includes(tag)) {
-    return text;
-  }
+  text = trimTrailingSpaces(text);
+  text = trimEmptyLines(text);
+  text = capitalizer(text);
 
   if (!text) return text;
 
-  const { printWidth = 80 } = options;
-
-  /**
-   * Description
-   *
-   * # Example
-   *
-   * Summry
-   */
-  text = text.replace(/\s+(#{1,6})(.*)$\s+/gm, "\n\n$1 $2\n\n");
-
-  /**
-   * 1. a thing
-   *
-   * 2. another thing
-   */
-  text = text.replace(/^(\d+)[-.][\s-.|]+/g, "$1. "); // Start
-
-  text = text.replace(/\n\s+[1][-.][\s-.|]+/g, EMPTY_LINE_SIGNATURE + "1. "); // add an empty line before of `1.`
-
-  text = text.replace(
-    /\s+(\d+)[-.][\s-.|]+/g,
-    NEW_LINE_START_WITH_NUMBER + "$1. ",
-  );
-
-  const codes = text.match(/[\s|]*```[\s\S]*?^[ \t]*```\s*/gm);
-
-  if (codes) {
-    codes.forEach((code) => {
-      text = text.replace(code, `\n\n${CODE}\n\n`);
-    });
+  const { printWidth } = options;
+  let { firstLinePrintWidth = printWidth } = formatOptions ?? {};
+  if (firstLinePrintWidth > printWidth) {
+    firstLinePrintWidth = printWidth;
   }
 
-  text = text.replace(
-    /(\n(\s+|)(---(\s|-)+)\n)/g, // `------- --- --- -` | `----`
-    NEW_DASH_LINE,
-  );
+  const shortFirstLine =
+    firstLinePrintWidth > 1 &&
+    firstLinePrintWidth < printWidth &&
+    !needsItsOwnLine(text);
 
-  text = text.replace(
-    /(\n(\s+|)\n\s\s\s+)/g,
-    NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE,
-  ); // Add a signature for new paragraph start with three space
+  if (shortFirstLine) {
+    const prefix = "Z".repeat(printWidth - firstLinePrintWidth - 1) + " ";
+    text = prefix + text;
 
-  text = text.replace(
-    /(\n\n+(\s+|)-(\s+|))/g, // `\n\n - ` | `\n\n-` | `\n\n -` | `\n\n- `
-    NEW_PARAGRAPH_START_WITH_DASH,
-  );
+    text =
+      tryFormat(text, {
+        ...options,
+        parser: "markdown",
+        proseWrap: "always",
+      }) ?? text;
 
-  text = text.replace(
-    /\n\s*-\s*/g, // `\n - ` | `\n-` | `\n -` | `\n- `
-    NEW_LINE_START_WITH_DASH,
-  );
-
-  text = text.replace(/(\n\n)|(\n\s+\n)/g, EMPTY_LINE_SIGNATURE); // Add a signature for empty line and use that later
-  // text = text.replace(/\n\s\s\s+/g, NEW_LINE_START_THREE_SPACE_SIGNATURE); // Add a signature for new line start with three space
-
-  text = capitalizer(text);
-
-  text = `${"_".repeat(tagString.length)}${text}`;
-
-  // Wrap tag description
-  const beginningSpace = tag === DESCRIPTION ? "" : "  "; // google style guide space
-  const marginLength = tagString.length;
-  let maxWidth = printWidth - column - 3; // column is location of comment, 3 is ` * `
-
-  if (marginLength >= maxWidth) {
-    maxWidth = marginLength;
+    text = text.replace(/^Z+[ ]*/, "");
+  } else {
+    text =
+      tryFormat(text, {
+        ...options,
+        parser: "markdown",
+        proseWrap: "always",
+      }) ?? text;
   }
 
-  text = text
-    .split(NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE)
-    .map((newParagraph) => {
-      return newParagraph
-        .split(EMPTY_LINE_SIGNATURE)
-        .map(
-          (newEmptyLineWithDash) =>
-            newEmptyLineWithDash
-              .split(NEW_LINE_START_WITH_NUMBER)
-              .map(
-                (newLineWithNumber) =>
-                  newLineWithNumber
-                    .split(NEW_DASH_LINE)
-                    .map(
-                      (newDashLine) =>
-                        newDashLine
-                          .split(NEW_PARAGRAPH_START_WITH_DASH)
-                          .map(
-                            (newLineWithDash) =>
-                              newLineWithDash
-                                .split(NEW_LINE_START_WITH_DASH)
-                                .map((paragraph) => {
-                                  paragraph = paragraph.replace(/\s+/g, " "); // Make single line
-
-                                  paragraph = capitalizer(paragraph);
-                                  if (options.jsdocDescriptionWithDot)
-                                    paragraph = paragraph.replace(
-                                      /(\w)$/g,
-                                      "$1.",
-                                    ); // Insert dot if needed
-
-                                  return breakDescriptionToLines(
-                                    paragraph,
-                                    maxWidth,
-                                    beginningSpace,
-                                  );
-                                })
-                                .join("\n- "), // NEW_LINE_START_WITH_DASH
-                          )
-                          .join("\n\n- "), // NEW_PARAGRAPH_START_WITH_DASH
-                    )
-                    .join(`\n    ${"-".repeat(printWidth / 2)}\n`), // NEW_DASH_LINE
-              )
-              .join("\n"), // NEW_LINE_START_WITH_NUMBER
-        )
-        .join("\n\n"); // EMPTY_LINE_SIGNATURE
-    })
-    .join("\n\n    "); // NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE;
-
-  const dashContent = text.match(/(^|\n)-(.+\n(?!(-)))+/g);
-
-  if (dashContent) {
-    dashContent.forEach((content) => {
-      text = text.replace(content, content.replace(/((?!(^))\n)/g, "\n  "));
-    });
-  }
-
-  const numberContent = text.match(/(^|\n)\d+.(.+\n(?!(\d+.)))+/g);
-
-  if (numberContent) {
-    numberContent.forEach((content) => {
-      text = text.replace(content, content.replace(/((?!(^))\n)/g, "\n   "));
-    });
-  }
-
-  if (codes) {
-    text = text.split(CODE).reduce((pre, cur, index) => {
-      return `${pre}${cur.trim()}${
-        codes[index]
-          ? `\n\n${format(codes[index], {
-              ...options,
-              parser: "markdown",
-              printWidth: printWidth - column,
-            }).trim()}\n\n`
-          : ""
-      }`;
-    }, "");
-  }
-
-  text = text.replace(/^_+/g, "");
-
-  return text || "";
+  return trimEmptyLines(text);
 }
 
-function breakDescriptionToLines(
-  desContent: string,
-  maxWidth: number,
-  beginningSpace: string,
-) {
-  let str = desContent.trim();
-
-  if (!str) {
-    return str;
-  }
-  const extraLastLineWidth = 10;
-  let result = "";
-  while (str.length > maxWidth + extraLastLineWidth) {
-    let sliceIndex = str.lastIndexOf(" ", maxWidth);
-    /**
-     * When a str is a long word lastIndexOf will gives 4 every time loop
-     * running on limited time
-     */
-    if (sliceIndex <= beginningSpace.length)
-      sliceIndex = str.indexOf(" ", beginningSpace.length + 1);
-
-    if (sliceIndex === -1) sliceIndex = str.length;
-
-    result += str.substring(0, sliceIndex);
-    str = str.substring(sliceIndex + 1);
-
-    str = `${beginningSpace}${str}`;
-    str = `\n${str}`;
-  }
-
-  result += str;
-
-  return result;
+function needsItsOwnLine(markdown: string): boolean {
+  return (
+    // list
+    /^\s*(?:\d+[.)]|[*])[\s-]/.test(markdown) ||
+    // code block
+    /^\s*```.*[\r\n]/.test(markdown) ||
+    // heading
+    /^\s*(?:#{1,6}.*|[^\s=-].*\n(?:===+|---+))/.test(markdown)
+  );
 }
 
 function convertCommentDescToDescTag(parsed: Comment): void {
@@ -262,12 +92,4 @@ function convertCommentDescToDescTag(parsed: Comment): void {
   }
 }
 
-export {
-  EMPTY_LINE_SIGNATURE,
-  NEW_LINE_START_WITH_DASH,
-  NEW_PARAGRAPH_START_WITH_DASH,
-  NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE,
-  descriptionEndLine,
-  convertCommentDescToDescTag,
-  formatDescription,
-};
+export { convertCommentDescToDescTag, formatDescription };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -71,7 +71,11 @@ export const getParser = (parser: Parser["parse"]) =>
         return;
       }
 
-      const commentIndentationWidth = getIndentationWidth(comment, options);
+      const commentIndentationWidth = getIndentationWidth(
+        comment,
+        text,
+        options,
+      );
       const CONTENT_PREFIX = " * ";
       const commentContentPrintWidth =
         options.printWidth - commentIndentationWidth - CONTENT_PREFIX.length;
@@ -92,7 +96,7 @@ export const getParser = (parser: Parser["parse"]) =>
             ...restInfo
           }) => {
             name = (name || "").trim();
-            description = trimTrailingSpaces((description || "").trim());
+            description = (description || "").trim();
 
             /** When space between tag and type missed */
             const tagSticksToType = tag.indexOf("{");
@@ -214,11 +218,23 @@ function isBlockComment(comment: PrettierComment): boolean {
 
 function getIndentationWidth(
   comment: PrettierComment,
+  text: string,
   options: JsdocOptions,
 ): number {
-  let width = comment.loc.start.column;
-  if (options.useTabs) {
-    width *= options.tabWidth;
+  const line = text.split(/\r\n|\n/g)[comment.loc.start.line - 1];
+
+  let spaces = 0;
+  let tabs = 0;
+  for (let i = comment.loc.start.column - 1; i >= 0; i--) {
+    const c = line[i];
+    if (c === " ") {
+      spaces++;
+    } else if (c === "\t") {
+      tabs++;
+    } else {
+      break;
+    }
   }
-  return width;
+
+  return spaces + tabs * options.tabWidth;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,7 +109,9 @@ function trimIndentation(string: string): string {
 
   let kind = IndentationKind.UNKNOWN;
   let min = Infinity;
-  for (let i = 0; i < lines.length; i++) {
+
+  const skipFirst = !/^[ \t]/.test(lines[0]);
+  for (let i = skipFirst ? 1 : 0; i < lines.length; i++) {
     const line = lines[i];
     if (line) {
       const first = line[0];
@@ -147,7 +149,9 @@ function trimIndentation(string: string): string {
   if (min === 0 || min === Infinity) {
     return lines.join("\n");
   } else {
-    return lines.map((line) => line.slice(min)).join("\n");
+    return lines
+      .map((line, i) => (i === 0 && skipFirst ? line : line.slice(min)))
+      .join("\n");
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,16 +89,89 @@ function formatType(type: string, options?: Options): string {
   }
 }
 
-function addStarsToTheBeginningOfTheLines(comment: string): string {
-  if (numberOfAStringInString(comment.trim(), "\n") === 0) {
-    return `* ${comment.trim()} `;
+function trimEmptyLines(string: string): string {
+  return string.replace(/^[\r\n]+|[\r\n]+$/g, "");
+}
+function trimTrailingSpaces(string: string): string {
+  return string
+    .split(/\n/g)
+    .map((line) => line.trimEnd())
+    .join("\n");
+}
+function trimIndentation(string: string): string {
+  const lines = string.split(/\n/g);
+
+  const enum IndentationKind {
+    SPACES,
+    TABS,
+    UNKNOWN,
   }
 
-  return `*${comment.replace(/(\n(?!$))/g, "\n * ")}\n `;
+  let kind = IndentationKind.UNKNOWN;
+  let min = Infinity;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line) {
+      const first = line[0];
+
+      if (first === " ") {
+        if (kind === IndentationKind.TABS) {
+          break;
+        } else {
+          kind = IndentationKind.SPACES;
+        }
+      } else if (first === "\t") {
+        if (kind === IndentationKind.SPACES) {
+          break;
+        } else {
+          kind = IndentationKind.TABS;
+        }
+      } else {
+        min = 0;
+        break;
+      }
+
+      let lineIndent = 1;
+      for (let j = 1; j < line.length; j++) {
+        if (line[j] === first) {
+          lineIndent++;
+        } else {
+          break;
+        }
+      }
+
+      min = Math.min(min, lineIndent);
+    }
+  }
+
+  if (min === 0 || min === Infinity) {
+    return lines.join("\n");
+  } else {
+    return lines.map((line) => line.slice(min)).join("\n");
+  }
 }
 
-function numberOfAStringInString(string: string, search: string | RegExp) {
-  return (string.match(new RegExp(search, "g")) || []).length;
+function countLines(string: string): number {
+  return string.split(/\n/g).length;
+}
+function getFirstLine(string: string): string {
+  const lines = string.split(/\n/g);
+  return lines[0];
+}
+function getLastLine(string: string): string {
+  const lines = string.split(/\n/g);
+  return lines[lines.length - 1];
+}
+
+function prefixLinesWith(
+  string: string,
+  prefix: string,
+  ignoreEmpty?: boolean,
+): string {
+  return string
+    .split(/\n/g)
+    .map((line) => (ignoreEmpty && line.length === 0 ? "" : prefix + line))
+    .join("\n");
 }
 
 // capitalize if needed
@@ -118,9 +191,24 @@ function capitalizer(str: string): string {
   return str[0].toUpperCase() + str.slice(1);
 }
 
+function tryFormat(source: string, options?: Options): string | undefined {
+  try {
+    return format(source, options);
+  } catch (error) {
+    return undefined;
+  }
+}
+
 export {
   convertToModernType,
   formatType,
-  addStarsToTheBeginningOfTheLines,
   capitalizer,
+  trimEmptyLines,
+  trimIndentation,
+  trimTrailingSpaces,
+  countLines,
+  getFirstLine,
+  getLastLine,
+  prefixLinesWith,
+  tryFormat,
 };

--- a/tests/__snapshots__/exampleTag.test.js.snap
+++ b/tests/__snapshots__/exampleTag.test.js.snap
@@ -99,6 +99,20 @@ exports[`example json  1`] = `
 "
 `;
 
+exports[`example with unknown language should be same after few time format  1`] = `
+"/**
+ * @example
+ *   Prism.languages['css-with-colors'] = Prism.languages.extend('css', {
+ *       // Prism.languages.css already has a 'comment' token, so this token will overwrite CSS' 'comment' token
+ *       // at its original position
+ *       'comment': { ... },
+ *       // CSS doesn't have a 'color' token, so this token will be appended
+ *       'color': /\\\\b(?:red|green|blue)\\\\b/
+ *   });
+ */
+"
+`;
+
 exports[`examples Json 1`] = `
 "/**
  * @example

--- a/tests/__snapshots__/files.test.js.snap
+++ b/tests/__snapshots__/files.test.js.snap
@@ -60,18 +60,18 @@ class test {
    * Replaces text in a string, using a regular expression or search string.
    *
    * @param {string | RegExp} searchValue A string to search for.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-   *   string containing the text to replace for every successful match of
-   *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-   *   string containing the text to replace for every successful match of
-   *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   * A string containing the text to replace for every successful match of
+   * searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   * A string containing the text to replace for every successful match of
+   * searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   * A_big_string_for_test string containing the text to replace for every
+   * successful match of searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   * A_big_string_for_test string containing the text to replace for every
+   * successful match of searchValue in this string.
    * @returns {StarkStringType & NativeString}
    */
   replace(searchValue, replaceValue) {
@@ -80,18 +80,18 @@ class test {
        * Replaces text in a string, using a regular expression or search string.
        *
        * @param {string | RegExp} searchValue A string to search for.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-       *   string containing the text to replace for every successful match of
-       *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-       *   string containing the text to replace for every successful match of
-       *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       * A string containing the text to replace for every successful match of
+       * searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       * A string containing the text to replace for every successful match of
+       * searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       * A_big_string_for_test string containing the text to replace for every
+       * successful match of searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       * A_big_string_for_test string containing the text to replace for every
+       * successful match of searchValue in this string.
        * @returns {StarkStringType & NativeString}
        */
       testFunction() {}
@@ -170,18 +170,18 @@ class test {
    * Replaces text in a string, using a regular expression or search string.
    *
    * @param {string | RegExp} searchValue A string to search for.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-   *   string containing the text to replace for every successful match of
-   *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-   *   string containing the text to replace for every successful match of
-   *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   * A string containing the text to replace for every successful match of
+   * searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   * A string containing the text to replace for every successful match of
+   * searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   * A_big_string_for_test string containing the text to replace for every
+   * successful match of searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   * A_big_string_for_test string containing the text to replace for every
+   * successful match of searchValue in this string.
    * @returns {StarkStringType & NativeString}
    */
   replace(searchValue: any, replaceValue: any) {
@@ -190,18 +190,18 @@ class test {
        * Replaces text in a string, using a regular expression or search string.
        *
        * @param {string | RegExp} searchValue A string to search for.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-       *   string containing the text to replace for every successful match of
-       *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-       *   string containing the text to replace for every successful match of
-       *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       * A string containing the text to replace for every successful match of
+       * searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       * A string containing the text to replace for every successful match of
+       * searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       * A_big_string_for_test string containing the text to replace for every
+       * successful match of searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       * A_big_string_for_test string containing the text to replace for every
+       * successful match of searchValue in this string.
        * @returns {StarkStringType & NativeString}
        */
       testFunction() {}
@@ -215,12 +215,12 @@ export interface FetchCallbackResponseArray<T, V> {
   resource: Resource<T>;
   /**
    * @deprecated Resolve clear with condition in your fetch api this function
-   *   will be remove
+   * will be remove
    */
   refetch: (...arg: V[]) => void;
   /**
    * @deprecated Resolve clear with condition in your fetch api this function
-   *   will be remove
+   * will be remove
    */
   clear: () => void;
 }

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -19,7 +19,10 @@ exports[`Bad defined name 1`] = `
 "/** @type {import(\\"@jest/types/build/Config\\").InitialOptions} */
 /** @type {{ foo: string }} */
 
-/** @typedef {import(\\"@jest/types/build/Config\\").InitialOptions} name A description */
+/**
+ * @typedef {import(\\"@jest/types/build/Config\\").InitialOptions} name A
+ * description
+ */
 "
 `;
 
@@ -84,12 +87,13 @@ exports[`Long description memory leak 1`] = `
  * https://example.com
  *
  * @param {LogLevel | string | ILogger} logging A {@link
- *   @microsoft/signalr.LogLevel}, a string representing a LogLevel, or an
- *   object implementing the {@link @microsoft/signalr.ILogger} interface.
- *   See {@link
- *   https://docs.microsoft.com/aspnet/core/signalr/configuration#configure-logging|the
- *   documentation for client logging configuration} for more details.
- * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
+ * @microsoft/signalr.LogLevel}, a string representing a LogLevel, or an
+ * object implementing the {@link @microsoft/signalr.ILogger} interface. See
+ * {@link
+ * https://docs.microsoft.com/aspnet/core/signalr/configuration#configure-logging|the
+ * documentation for client logging configuration} for more details.
+ * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for
+ * chaining.
  */
 "
 `;
@@ -123,11 +127,15 @@ exports[`Should align vertically param|property|returns|yields|throws if option 
 
 exports[`Should align vertically param|property|returns|yields|throws if option set to true, and amount of spaces is different than default 2`] = `
 "/**
- * @property    {Object}            unalginedProp     Unaligned property descriptin
- * @param       {String}            unalginedParam    Unaligned param description
- * @throws      {CustomExceptio}                      Unaligned throws description
+ * @property    {Object}            unalginedProp     Unaligned property
+ * descriptin
+ * @param       {String}            unalginedParam    Unaligned param
+ * description
+ * @throws      {CustomExceptio}                      Unaligned throws
+ * description
  * @yields      {Number}                              Yields description
- * @returns     {String}                              Unaligned returns description
+ * @returns     {String}                              Unaligned returns
+ * description
  */
 "
 `;
@@ -176,9 +184,9 @@ exports[`Should format jsDoc default values 2`] = `
 exports[`Should format regular jsDoc 1`] = `
 "/**
  * Function example description that was wrapped by hand so it have more then
- * one line and don't end with a dot REPEATED TWO TIMES BECAUSE IT WAS EASIER
- * to copy function example description that was wrapped by hand so it have
- * more then one line.
+ * one line and don't end with a dot REPEATED TWO TIMES BECAUSE IT WAS EASIER to
+ * copy function example description that was wrapped by hand so it have more
+ * then one line.
  *
  * @async
  * @private
@@ -192,7 +200,7 @@ exports[`Should format regular jsDoc 1`] = `
  *   }
  *
  * @param {String | Number} text - Some text description that is very long and
- *   needs to be wrapped
+ * needs to be wrapped
  * @param {String} [defaultValue=\\"defaultTest\\"] TODO. Default is \`\\"defaultTest\\"\`
  * @param {Number | Null} [optionalNumber]
  * @undefiendTag
@@ -206,9 +214,9 @@ const testFunction = (text, defaultValue, optionalNumber) => true;
 exports[`Should format regular jsDoc 2`] = `
 "/**
  * Function example description that was wrapped by hand so it have more then
- * one line and don't end with a dot REPEATED TWO TIMES BECAUSE IT WAS EASIER
- * to copy function example description that was wrapped by hand so it have
- * more then one line.
+ * one line and don't end with a dot REPEATED TWO TIMES BECAUSE IT WAS EASIER to
+ * copy function example description that was wrapped by hand so it have more
+ * then one line.
  *
  * @async
  * @private
@@ -222,7 +230,7 @@ exports[`Should format regular jsDoc 2`] = `
  *   }
  *
  * @param {String | Number} text - Some text description that is very long and
- *   needs to be wrapped
+ * needs to be wrapped
  * @param {String} [defaultValue=\\"defaultTest\\"] TODO. Default is \`\\"defaultTest\\"\`
  * @param {Number | Null} [optionalNumber]
  * @undefiendTag
@@ -236,7 +244,7 @@ const testFunction = (text, defaultValue, optionalNumber) => true;
 exports[`Should insert proper amount of spaces based on option 1`] = `
 "/**
  * @param  {Object}  paramName  Param description that goes on and on and on
- *   utill it will need to be wrapped
+ * utill it will need to be wrapped
  * @returns  {Number}  Return description
  */
 "
@@ -245,7 +253,7 @@ exports[`Should insert proper amount of spaces based on option 1`] = `
 exports[`Should insert proper amount of spaces based on option 2`] = `
 "/**
  * @param   {Object}   paramName   Param description that goes on and on and on
- *   utill it will need to be wrapped
+ * utill it will need to be wrapped
  * @returns   {Number}   Return description
  */
 "

--- a/tests/__snapshots__/modern.test.js.snap
+++ b/tests/__snapshots__/modern.test.js.snap
@@ -6,7 +6,8 @@ exports[`convert array to modern type 1`] = `
  * @param {Adaptable} animNode
  * @param {object} InterpolationConfig
  * @param {ReadonlyArray<Adaptable>} InterpolationConfig.inputRange Like [0,1]
- * @param {string[]} InterpolationConfig.outputRange Like [\\"#0000ff\\",\\"#ff0000\\"]
+ * @param {string[]} InterpolationConfig.outputRange Like
+ * [\\"#0000ff\\",\\"#ff0000\\"]
  * @param {import(\\"react-native-reanimated\\").default.Extrapolate} [InterpolationConfig.extrapolate]
  * @param {Foo<Bar>[]} arg1
  * @param {((item: Foo<Bar>) => Bar<number>)[] | number[] | string[]} arg2

--- a/tests/__snapshots__/objectProperty.test.js.snap
+++ b/tests/__snapshots__/objectProperty.test.js.snap
@@ -10,7 +10,7 @@ exports[`object property 1`] = `
 /**
  * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
  *
- *     This source code is licensed under the license found in the LICENSE file in
+ * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
 

--- a/tests/__snapshots__/paragraph.test.js.snap
+++ b/tests/__snapshots__/paragraph.test.js.snap
@@ -15,9 +15,9 @@ exports[`code in description 1`] = `
  *
  * - When a touch was activated (typically you highlight)
  * - When a touch was deactivated (typically you unhighlight)
- * - When a touch was \\"pressed\\" - a touch ended while still within the geometry of
- *   the element, and no other element (like scroller) has \\"stolen\\" touch lock
- *   (\\"responder\\") (Typically you bounce the element).
+ * - When a touch was \\"pressed\\" - a touch ended while still within the geometry
+ *   of the element, and no other element (like scroller) has \\"stolen\\" touch
+ *   lock (\\"responder\\") (Typically you bounce the element).
  *
  * A good tap interaction isn't as simple as you might think. There should be a
  * slight delay before showing a highlight when starting a touch. If a
@@ -40,9 +40,9 @@ exports[`code in description 1`] = `
  * \`\`\`
  *
  * - Choose the rendered component who's touches should start the interactive
- *   sequence. On that rendered node, forward all \`Touchable\` responder handlers.
- *   You can choose any rendered node you like. Choose a node whose hit target
- *   you'd like to instigate the interaction sequence:
+ *   sequence. On that rendered node, forward all \`Touchable\` responder
+ *   handlers. You can choose any rendered node you like. Choose a node whose
+ *   hit target you'd like to instigate the interaction sequence:
  *
  * \`\`\`js
  * // In render function:
@@ -58,9 +58,9 @@ exports[`code in description 1`] = `
  *     onResponderTerminate={this.touchableHandleResponderTerminate}
  *   >
  *     <View>
- *       Even though the hit detection/interactions are triggered by the wrapping
- *       (typically larger) node, we usually end up implementing custom logic that
- *       highlights this inner one.
+ *       Even though the hit detection/interactions are triggered by the
+ *       wrapping (typically larger) node, we usually end up implementing custom
+ *       logic that highlights this inner one.
  *     </View>
  *   </View>
  * );
@@ -85,7 +85,8 @@ exports[`code in description 1`] = `
  *   },
  * \`\`\`
  *
- * - There are more advanced methods you can implement (see documentation below):
+ * - There are more advanced methods you can implement (see documentation
+ *   below):
  *
  * \`\`\`js
  *   touchableGetHighlightDelayMS: function() {
@@ -127,9 +128,11 @@ exports[`description contain paragraph 1`] = `
 "/**
  * Does the following things:
  *
- * 1. Thing 1
- * 2. Thing 2
- * 3. Thing 3
+ * 1.  Thing 1
+ *
+ * 2.  Thing 2
+ *
+ * 3.  Thing 3
  */
 "
 `;
@@ -138,9 +141,9 @@ exports[`description contain paragraph 2`] = `
 "/**
  * Does the following things:
  *
- * 1. Thing 1
- * 2. Thing 2
- * 3. Thing 3
+ * 1.  Thing 1
+ * 2.  Thing 2
+ * 3.  Thing 3
  */
 "
 `;
@@ -157,7 +160,7 @@ exports[`description contain paragraph 3`] = `
    * pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa
    * qui officia deserunt mollit anim id est laborum.
    *
-   * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+   * lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
    * tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
    * veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
    * commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
@@ -166,8 +169,8 @@ exports[`description contain paragraph 3`] = `
    * mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur
    * adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
    * magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-   * laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-   * in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+   * laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+   * reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
    * pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa
    * qui officia deserunt mollit anim id est laborum.
    */
@@ -184,7 +187,8 @@ exports[`description contain paragraph 4`] = `
  */
 
 /**
- * Bounce give a renderContent and show that around children when isVisible is true
+ * Bounce give a renderContent and show that around children when isVisible is
+ * true
  *
  * @example
  *   <Bounce
@@ -208,28 +212,35 @@ exports[`description new line with dash 1`] = `
  * during an - animation. This is a very useful default that happens to
  * satisfy many common user experiences.
  *
- * - Stop a scroll on the left edge, then turn that into an outer view's backswipe.
- * - Stop a scroll mid-bounce at the top, continue pulling to have the outer view dismiss.
+ * - Stop a scroll on the left edge, then turn that into an outer view's
+ *   backswipe.
+ * - Stop a scroll mid-bounce at the top, continue pulling to have the outer
+ *   view dismiss.
  * - However, without catching the scroll view mid-bounce (while it is
  *   motionless), if you drag far enough for the scroll view to become
  *   responder (and therefore drag the scroll view a bit), any backswipe
- *   navigation of a swipe gesture higher in the view hierarchy, should be rejected.
+ *   navigation of a swipe gesture higher in the view hierarchy, should be
+ *   rejected.
  */
 function scrollResponderHandleTerminationRequest() {
   return !this.state.observedScrollSinceBecomingResponder;
 }
 
 /**
- * - Stop a scroll on the left edge, then turn that into an outer view's backswipe.
- * - Stop a scroll mid-bounce at the top, continue pulling to have the outer view dismiss.
+ * - Stop a scroll on the left edge, then turn that into an outer view's
+ *   backswipe.
+ * - Stop a scroll mid-bounce at the top, continue pulling to have the outer
+ *   view dismiss.
  */
 function scrollResponderHandleTerminationRequest() {
   return !this.state.observedScrollSinceBecomingResponder;
 }
 
 /**
- * - Stop a scroll on the left edge, then turn that into an outer view's backswipe.
- * - Stop a scroll mid-bounce at the top, continue pulling to have the outer view dismiss.
+ * - Stop a scroll on the left edge, then turn that into an outer view's
+ *   backswipe.
+ * - Stop a scroll mid-bounce at the top, continue pulling to have the outer
+ *   view dismiss.
  */
 function scrollResponderHandleTerminationRequest() {
   return !this.state.observedScrollSinceBecomingResponder;
@@ -244,11 +255,10 @@ exports[`description new line with dash 2`] = `
  * should result in points that are in the same coordinate system as an
  * event's \`globalX/globalY\` data values.
  *
- * - Consider caching this for the lifetime of the component, or possibly being
- *   able to share this cache between any \`ScrollMap\` view.
+ * - Consider caching this for the lifetime of the component, or possibly
+ *   being able to share this cache between any \`ScrollMap\` view.
  *
  * @private
- *
  * @sideeffects
  */
 "
@@ -265,16 +275,16 @@ exports[`description new line with dash 3`] = `
  * The test case file can either consist of two parts:
  *
  *     {source code}
- *     ----------------------------------------
- * {expected token stream}
+ *     ----
+ *     {expected token stream}
  *
  * or of three parts:
  *
  *     {source code}
- *     ----------------------------------------
- * {expected token stream}
- *     ----------------------------------------
- * {text comment explaining the test case}
+ *     ----
+ *     {expected token stream}
+ *     ----
+ *     {text comment explaining the test case}
  *
  * If the file contains more than three parts, the remaining parts are just
  * ignored. If the file however does not contain at least two parts (so no
@@ -285,7 +295,7 @@ exports[`description new line with dash 3`] = `
 
 exports[`numbers and code in description 1`] = `
 "/**
- * =========================== PressResponder Tutorial ===========================
+ * ======================= PressResponder Tutorial =======================
  *
  * The \`PressResponder\` class helps you create press interactions by analyzing
  * the geometry of elements and observing when another responder (e.g.
@@ -299,31 +309,25 @@ exports[`numbers and code in description 1`] = `
  *
  * A high quality interaction isn't as simple as you might think. There should
  * be a slight delay before activation. Moving your finger beyond an element's
- * bounds should trigger deactivation, but moving the same finger back within
- * an element's bounds should trigger reactivation.
+ * bounds should trigger deactivation, but moving the same finger back within an
+ * element's bounds should trigger reactivation.
  *
  * 1. In order to use \`PressResponder\`, do the following:
- *
- * \`\`\`js
- * const pressResponder = new PressResponder(config);
- * \`\`\`
- *
+ *    \`\`\`js
+ *    const pressResponder = new PressResponder(config);
+ *    \`\`\`
  * 2. Choose the rendered component who should collect the press events. On that
  *    element, spread \`pressability.getEventHandlers()\` into its props.
- *
- * \`\`\`js
- * return <View {...this.state.pressResponder.getEventHandlers()} />;
- * \`\`\`
- *
+ *    \`\`\`js
+ *    return <View {...this.state.pressResponder.getEventHandlers()} />;
+ *    \`\`\`
  * 3. Reset \`PressResponder\` when your component unmounts.
- *
- * \`\`\`js
+ *    \`\`\`js
  *    componentWillUnmount() {
  *      this.state.pressResponder.reset();
  *    }
- * \`\`\`
- *
- * ==================== Implementation Details ====================
+ *    \`\`\`
+ *    ==================== Implementation Details ====================
  *
  * \`PressResponder\` only assumes that there exists a \`HitRect\` node. The
  * \`PressRect\` is an abstract box that is extended beyond the \`HitRect\`.
@@ -338,32 +342,89 @@ exports[`numbers and code in description 1`] = `
 
 exports[`numbers and code in description 2`] = `
 "/**
- * 1. a keydown event occurred immediately before a focus event
- * 2. a focus event happened on an element which requires keyboard interaction
- *       (e.g., a text field);
- * 2. a focus event happened on an element which requires keyboard interaction
- * (e.g., a text field);
+ * 1- a keydown event occurred immediately before a focus event 2- a focus
+ * event happened on an element which requires keyboard interaction (e.g., a
+ * text field); 2- a focus event happened on an element which requires
+ * keyboard interaction (e.g., a text field);
  */
 "
 `;
 
 exports[`numbers and code in description 3`] = `
 "/**
- * The script uses two heuristics to determine whether the keyboard is being used:
+ * The script uses two heuristics to determine whether the keyboard is being
+ * used:
  *
  * 1. a keydown event occurred lorem ipsum dolor sit amet, consectetur
- *    adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
- *    aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
- *    nisi ut aliqimmediately before a focus event;
+ *    adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+ *    magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+ *    laboris nisi ut aliqimmediately before a focus event;
+ *
  * 2. a focus evenlorem ipsum dolor sit amet, consectetur adipiscing elit, sed
  *    do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
  *    minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqt
- *    happened on an element which requires keyboard interaction (e.g., a text field);
+ *    happened on an element which requires keyboard interaction (e.g., a text
+ *    field);
  *
- * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+ * lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
  * tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
  * quis nostrud exercitation ullamco laboris nisi ut aliq W3C Software Notice
- * and License: https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ * and License:
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
  */
+"
+`;
+
+exports[`with indentation 1`] = `
+"/**
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+ * tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+ * quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+ * consequat.
+ */
+const foo = {
+        /**
+         * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+         * eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+         * ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+         * aliquip ex ea commodo consequat.
+         */
+        baz: {
+                /**
+                 * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                 * do eiusmod tempor incididunt ut labore et dolore magna
+                 * aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                 * ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                 */
+                bar() {},
+        },
+};
+"
+`;
+
+exports[`with tab indentation 1`] = `
+"/**
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+ * tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+ * quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+ * consequat.
+ */
+const foo = {
+	/**
+	 * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+	 * eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+	 * ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+	 * aliquip ex ea commodo consequat.
+	 */
+	baz: {
+		/**
+		 * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+		 * do eiusmod tempor incididunt ut labore et dolore magna
+		 * aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+		 * ullamco laboris nisi ut aliquip ex ea commodo consequat.
+		 */
+		bar() {},
+	},
+};
 "
 `;

--- a/tests/__snapshots__/react.test.js.snap
+++ b/tests/__snapshots__/react.test.js.snap
@@ -11,17 +11,17 @@ import { useLayout, useInlineStyle } from \\"./hooks\\";
 /**
  * @typedef {object} XAxisProps
  * @property {number} [spacingOuter] Spacing between the labels. Only
- *   applicable if \`scale=d3Scale.scaleBand\` and should then be equal to
- *   \`spacingOuter\` prop on the actual BarChart
+ * applicable if \`scale=d3Scale.scaleBand\` and should then be equal to
+ * \`spacingOuter\` prop on the actual BarChart
  *
  * Default is \`0.05\`
  * @property {number} [spacingInner] Spacing between the labels. Only
- *   applicable if \`scale=d3Scale.scaleBand\` and should then be equal to
- *   \`spacingInner\` prop on the actual BarChart
+ * applicable if \`scale=d3Scale.scaleBand\` and should then be equal to
+ * \`spacingInner\` prop on the actual BarChart
  *
  * Default is \`0.05\`
  * @property {d3Scale.scaleLinear} [scale] Should be the same as passed into
- *   the charts \`xScale\` Default is \`d3Scale.scaleLinear\`
+ * the charts \`xScale\` Default is \`d3Scale.scaleLinear\`
  * @property {() => any} [xAccessor] Default is \`({index}) => index\`
  * @property {number} [max]
  * @property {number} [min]

--- a/tests/__snapshots__/singleTag.test.js.snap
+++ b/tests/__snapshots__/singleTag.test.js.snap
@@ -5,7 +5,9 @@ exports[`single tag 1`] = `
 function fun(param0) {}
 
 export const SubDomain = {
-  /** @returns {import(\\"axios\\").AxiosResponse<import(\\"../types\\").SubDomain>} */
+  /**
+   * @returns {import(\\"axios\\").AxiosResponse<import(\\"../types\\").SubDomain>}
+   */
   async subDomain(subDomainAddress) {},
 };
 "

--- a/tests/__snapshots__/typeScript.test.js.snap
+++ b/tests/__snapshots__/typeScript.test.js.snap
@@ -63,12 +63,12 @@ exports[`description in interface 1`] = `
   resource: Resource<T>;
   /**
    * @deprecated Resolve clear with condition in your fetch api this function
-   *   will be remove
+   * will be remove
    */
   refetch: (...arg: V[]) => void;
   /**
    * @deprecated Resolve clear with condition in your fetch api this function
-   *   will be remove
+   * will be remove
    */
   clear: () => void;
 }
@@ -98,18 +98,18 @@ exports[`max width challenge 1`] = `
    * Replaces text in a string, using a regular expression or search string.
    *
    * @param {string | RegExp} searchValue A string to search for.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-   *   string containing the text to replace for every successful match of
-   *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-   *   string containing the text to replace for every successful match of
-   *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   * A string containing the text to replace for every successful match of
+   * searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   * A string containing the text to replace for every successful match of
+   * searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   * A_big_string_for_test string containing the text to replace for every
+   * successful match of searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   * A_big_string_for_test string containing the text to replace for every
+   * successful match of searchValue in this string.
    * @returns {StarkStringType & NativeString}
    */
   replace(searchValue, replaceValue) {
@@ -118,18 +118,18 @@ exports[`max width challenge 1`] = `
        * Replaces text in a string, using a regular expression or search string.
        *
        * @param {string | RegExp} searchValue A string to search for.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-       *   string containing the text to replace for every successful match of
-       *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-       *   string containing the text to replace for every successful match of
-       *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       * A string containing the text to replace for every successful match of
+       * searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       * A string containing the text to replace for every successful match of
+       * searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       * A_big_string_for_test string containing the text to replace for every
+       * successful match of searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       * A_big_string_for_test string containing the text to replace for every
+       * successful match of searchValue in this string.
        * @returns {StarkStringType & NativeString}
        */
       testFunction() {}

--- a/tests/exampleTag.test.js
+++ b/tests/exampleTag.test.js
@@ -22,7 +22,7 @@ test("Example javascript code", () => {
 
  }
 
-* @undefiendTag 
+* @undefiendTag
 * @undefiendTag {number} name des
 */
 const testFunction = (text, defaultValue, optionalNumber) => true
@@ -54,7 +54,7 @@ test("examples Json", () => {
   };
   const Result1 = subject(
     `/**
- * @example 
+ * @example
  * {testArr: [
  *     1,
  *     2,
@@ -67,7 +67,7 @@ test("examples Json", () => {
   const Result2 = subject(
     `/**
  * @example
- * 
+ *
  * [{
  *   foo: 1,
  *   foo: 2,
@@ -87,7 +87,7 @@ test("Example start by xml tag", () => {
   const result = subject(`
   /**
    * @example <caption>TradingViewChart</caption>;
-   * 
+   *
    * export default Something
    */
 `);
@@ -145,6 +145,36 @@ test("example should be same after few time format ", () => {
 
   const result2 = subject(result);
   const result3 = subject(result2);
+
+  expect(result).toEqual(result2);
+  expect(result).toEqual(result3);
+});
+
+test("example with unknown language should be same after few time format ", () => {
+  const options = { jsdocKeepUnParseAbleExampleIndent: true };
+
+  // the `'comment': { ... }` line makes it invalid JS
+  const result = subject(
+    `
+  /**
+   * @example
+   *   Prism.languages['css-with-colors'] = Prism.languages.extend('css', {
+   *       // Prism.languages.css already has a 'comment' token, so this token will overwrite CSS' 'comment' token
+   *       // at its original position
+   *       'comment': { ... },
+   *       // CSS doesn't have a 'color' token, so this token will be appended
+   *       'color': /\\b(?:red|green|blue)\\b/
+   *   });
+   *
+  */
+`,
+    options,
+  );
+
+  expect(result).toMatchSnapshot();
+
+  const result2 = subject(result, options);
+  const result3 = subject(result2, options);
 
   expect(result).toEqual(result2);
   expect(result).toEqual(result3);

--- a/tests/paragraph.test.js
+++ b/tests/paragraph.test.js
@@ -16,11 +16,11 @@ test("description contain paragraph", () => {
   const result = subject(`
 /**
  * Does the following things:
- * 
+ *
  *    1. Thing 1
- * 
+ *
  *    2. Thing 2
- * 
+ *
  *    3. Thing 3
  */
     `);
@@ -30,7 +30,7 @@ test("description contain paragraph", () => {
   const result2 = subject(`
   /**
    * Does the following things:
-   * 
+   *
    *    1. Thing 1
    *    2. Thing 2
    *    3. Thing 3
@@ -61,7 +61,7 @@ test("description contain paragraph", () => {
    *
    * @override
    */
-   
+
 
   /**
    * Bounce give a renderContent and show that around children when isVisible is
@@ -79,7 +79,7 @@ test("description contain paragraph", () => {
    *
    * @type {React.FC<BounceProps>}
    */
-  
+
    `);
 
   expect(result4).toMatchSnapshot();
@@ -184,7 +184,7 @@ test("description new line with dash", () => {
 test("numbers and code in description", () => {
   const result1 = subject(`
 /**
- * =========================== PressResponder Tutorial ===========================
+ * ======================= PressResponder Tutorial =======================
  *
  * The \`PressResponder\` class helps you create press interactions by analyzing the
  * geometry of elements and observing when another responder (e.g. ScrollView)
@@ -200,23 +200,23 @@ test("numbers and code in description", () => {
  * bounds should trigger deactivation, but moving the same finger back within an
  * element's bounds should trigger reactivation.
  *
- * 1- In order to use \`PressResponder\`, do the following:
- *\`\`\`js
+ * 1. In order to use \`PressResponder\`, do the following:
+ *     \`\`\`js
  *     const pressResponder = new PressResponder(config);
- *\`\`\`
- *     2.   Choose the rendered component who should collect the press events. On that
- *   element, spread \`pressability.getEventHandlers()\` into its props.
- *\`\`\`js
+ *     \`\`\`
+ * 2. Choose the rendered component who should collect the press events. On that
+ *    element, spread \`pressability.getEventHandlers()\` into its props.
+ *    \`\`\`js
  *    return (
  *      <View {...this.state.pressResponder.getEventHandlers()} />
  *    );
- *\`\`\`
+ *    \`\`\`
  * 3. Reset \`PressResponder\` when your component unmounts.
- *\`\`\`js
+ *    \`\`\`js
  *    componentWillUnmount() {
  *      this.state.pressResponder.reset();
  *    }
- *\`\`\`
+ *    \`\`\`
  * ==================== Implementation Details ====================
  *
  * \`PressResponder\` only assumes that there exists a \`HitRect\` node. The \`PressRect\`
@@ -267,7 +267,7 @@ test("code in description", () => {
  * will measure time/geometry and tells you when to give feedback to the user.
  *
  * ====================== Touchable Tutorial ===============================
- * The \`Touchable\` mixin helps you handle the "press" interaction. It analyzes 
+ * The \`Touchable\` mixin helps you handle the "press" interaction. It analyzes
  *  the geometry of elements, and observes when another responder (scroll view
  * etc) has stolen the touch lock. It notifies your component when it should
  * give feedback to the user. (bouncing/highlighting/unhighlighting).
@@ -304,7 +304,7 @@ test("code in description", () => {
  *   // In render function:
  *   return (
  *     <View
- * 
+ *
  *       onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
  *       onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
  *       onResponderGrant={this.touchableHandleResponderGrant}
@@ -375,6 +375,60 @@ test("code in description", () => {
   expect(subject(subject(result2))).toEqual(result2);
 
   expect(result2).toMatchSnapshot();
+});
+
+test("with indentation", () => {
+  const result1 = subject(
+    `
+/**
+ * lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+ *
+ */
+const foo = {
+        /**
+         * lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+         *
+         */
+        baz: {
+                /**
+                 * lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                 *
+                 */
+                bar() {},
+        }
+}
+  `,
+    { tabWidth: 8 },
+  );
+
+  expect(result1).toMatchSnapshot();
+});
+
+test("with tab indentation", () => {
+  const result1 = subject(
+    `
+/**
+ * lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+ *
+ */
+const foo = {
+	/**
+	 * lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+	 *
+	 */
+	baz: {
+		/**
+		 * lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+		 *
+		 */
+		bar() {},
+	}
+}
+  `,
+    { useTabs: true, tabWidth: 8 },
+  );
+
+  expect(result1).toMatchSnapshot();
 });
 
 /**


### PR DESCRIPTION
I rewrote large parts of the parser and the whole stringify and formatting code.

Changes:
- The Markdown formatting is now handled by Prettier's MD formatter.
- Print width is now correctly enforced everywhere.
- The 2 extra spaces after a description line break have been removed. (E.g. when the desc of an `@param` couldn't fit into one line, all lines after the first one used to be intended with 2 spaces.)
- Paragraphs are no longer capitalized. Since Prettier's MD formatter doesn't do this, we now also don't. The only exception to this is the first character of any description, this one will be capitalized.

---

This fixes #25.
This fixes #26.
This fixes #32. (The current fix is not correct)