### PR TITLE
feat(type-formatter): support rest parameters

### DIFF
--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -37,6 +37,17 @@ exports[`Empty comment 1`] = `
 "
 `;
 
+exports[`Format rest parameters properly 1`] = `
+"/**
+ * @param {...any} arg1
+ * @param {...number} arg2
+ * @param {...(string | number)} arg3
+ * @param {...(string | number)} arg4 This is equivalent to arg3
+ */
+function a() {}
+"
+`;
+
 exports[`Hyphen at the start of description 1`] = `
 "/**
  * Assign the project to an employee.

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -427,3 +427,18 @@ test("Non-jsdoc comment", () => {
 
   expect(result).toMatchSnapshot();
 });
+
+test("Format rest parameters properly", () => {
+  const result = subject(`
+  /**
+   * @param {... *} arg1
+   * @param {... number} arg2
+   * @param {... (string|number)} arg3
+   * @param {... string|number} arg4 This is equivalent to arg3
+   *
+   */
+  function a(){}
+  `);
+
+  expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
Rest parameters weren't formatted since `type name = ...T` isn't valid TS.