### PR TITLE
fix: windows EOL now supported

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -145,9 +145,46 @@ function capitalizer(str: string): string {
   return str[0].toUpperCase() + str.slice(1);
 }
 
+/**
+ * Detects the line ends of the given text.
+ *
+ * If multiple line ends are used, the most common one will be returned.
+ *
+ * If the given text is a single line, "lf" will be returned.
+ *
+ * @param text
+ */
+function detectEndOfLine(text: string): "cr" | "crlf" | "lf" {
+  const counter = {
+    "\r": 0,
+    "\r\n": 0,
+    "\n": 0,
+  };
+
+  const lineEndPattern = /\r\n?|\n/g;
+  let m;
+  while ((m = lineEndPattern.exec(text))) {
+    counter[m[0] as keyof typeof counter]++;
+  }
+
+  const cr = counter["\r"];
+  const crlf = counter["\r\n"];
+  const lf = counter["\n"];
+  const max = Math.max(cr, crlf, lf);
+
+  if (lf === max) {
+    return "lf";
+  } else if (crlf === max) {
+    return "crlf";
+  } else {
+    return "cr";
+  }
+}
+
 export {
   convertToModernType,
   formatType,
   addStarsToTheBeginningOfTheLines,
   capitalizer,
+  detectEndOfLine,
 };

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -442,3 +442,36 @@ test("Format rest parameters properly", () => {
 
   expect(result).toMatchSnapshot();
 });
+
+test("Line ends", () => {
+  const text = `
+  /**
+   * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+   * @param {Object} paramName param description that goes on and on and on until it will need to be wrapped
+   *
+   */
+  function a(){}`;
+  const formatted = `/**
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+ * tempor incididunt ut labore et dolore magna aliqua.
+ *
+ * @param {Object} paramName Param description that goes on and on and on
+ *   until it will need to be wrapped
+ */
+function a() {}
+`;
+
+  const text_crlf = text.replace(/\n/g, "\r\n");
+  const text_lf = text;
+  const formatted_crlf = formatted.replace(/\n/g, "\r\n");
+  const formatted_lf = formatted;
+
+  expect(subject(text_lf, { endOfLine: "crlf" })).toEqual(formatted_crlf);
+  expect(subject(text_lf, { endOfLine: "lf" })).toEqual(formatted_lf);
+
+  expect(subject(text_crlf, { endOfLine: "crlf" })).toEqual(formatted_crlf);
+  expect(subject(text_crlf, { endOfLine: "lf" })).toEqual(formatted_lf);
+
+  expect(subject(text_lf, { endOfLine: "auto" })).toEqual(formatted_lf);
+  expect(subject(text_crlf, { endOfLine: "auto" })).toEqual(formatted_crlf);
+});


### PR DESCRIPTION
Windows EOL is now supported.

This is done by replacing whatever the current EOL is with `\n`. This means all of our code can now correctly assume that only `\n` is used. Line ends are converted back to whatever is configured at the end.

---

This fixes #48 