### PR TITLE
fix: indentation and printWidth

### DIFF
--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -37,19 +37,21 @@ function descriptionEndLine({
   return "";
 }
 
+interface FormatOptions {
+  firstLinePrintWidth?: number;
+}
+
 /**
  * Trim, make single line with capitalized text. Insert dot if flag for it is
  * set to true and last character is a word character
  *
  * @private
- * @param {Boolean} insertDot Flag for dot at the end of text
  */
 function formatDescription(
   tag: string,
   text: string,
-  tagString: string,
-  column: number,
   options: JsdocOptions,
+  formatOptions: FormatOptions = {},
 ): string {
   if (!TAGS_NEED_FORMAT_DESCRIPTION.includes(tag)) {
     return text;
@@ -57,7 +59,8 @@ function formatDescription(
 
   if (!text) return text;
 
-  const { printWidth = 80 } = options;
+  const { printWidth } = options;
+  const { firstLinePrintWidth = printWidth } = formatOptions;
 
   /**
    * Description
@@ -115,16 +118,10 @@ function formatDescription(
 
   text = capitalizer(text);
 
-  text = `${"_".repeat(tagString.length)}${text}`;
+  text = `${"_".repeat(Math.max(0, printWidth - firstLinePrintWidth))}${text}`;
 
   // Wrap tag description
   const beginningSpace = tag === DESCRIPTION ? "" : "  "; // google style guide space
-  const marginLength = tagString.length;
-  let maxWidth = printWidth - column - 3; // column is location of comment, 3 is ` * `
-
-  if (marginLength >= maxWidth) {
-    maxWidth = marginLength;
-  }
 
   text = text
     .split(NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE)
@@ -159,7 +156,7 @@ function formatDescription(
 
                                   return breakDescriptionToLines(
                                     paragraph,
-                                    maxWidth,
+                                    printWidth,
                                     beginningSpace,
                                   );
                                 })
@@ -198,7 +195,6 @@ function formatDescription(
           ? `\n\n${format(codes[index], {
               ...options,
               parser: "markdown",
-              printWidth: printWidth - column,
             }).trim()}\n\n`
           : ""
       }`;
@@ -269,5 +265,6 @@ export {
   NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE,
   descriptionEndLine,
   convertCommentDescToDescTag,
+  FormatOptions,
   formatDescription,
 };

--- a/tests/__snapshots__/files/prism-core.js.shot
+++ b/tests/__snapshots__/files/prism-core.js.shot
@@ -31,8 +31,8 @@ var Prism = (function (_self) {
 		 *
 		 * By setting this value to \`true\`, Prism will not automatically highlight all code elements on the page.
 		 *
-		 * You obviously have to change this value before the automatic highlighting started. To do this, you can add an empty
-		 * Prism object into the global scope before loading the Prism script like this:
+		 * You obviously have to change this value before the automatic highlighting started. To do this, you can add an
+		 * empty Prism object into the global scope before loading the Prism script like this:
 		 *
 		 * \`\`\`js
 		 * window.Prism = window.Prism || {};
@@ -220,16 +220,16 @@ var Prism = (function (_self) {
 			/**
 			 * Returns whether a given class is active for \`element\`.
 			 *
-			 * The class can be activated if \`element\` or one of its ancestors has the given class and it can be deactivated if
-			 * \`element\` or one of its ancestors has the negated version of the given class. The _negated version_ of the given
-			 * class is just the given class with a \`no-\` prefix.
+			 * The class can be activated if \`element\` or one of its ancestors has the given class and it can be deactivated
+			 * if \`element\` or one of its ancestors has the negated version of the given class. The _negated version_ of
+			 * the given class is just the given class with a \`no-\` prefix.
 			 *
-			 * Whether the class is active is determined by the closest ancestor of \`element\` (where \`element\` itself is closest
-			 * ancestor) that has the given class or the negated version of it. If neither \`element\` nor any of its ancestors
-			 * have the given class or the negated version of it, then the default activation will be returned.
+			 * Whether the class is active is determined by the closest ancestor of \`element\` (where \`element\` itself is
+			 * closest ancestor) that has the given class or the negated version of it. If neither \`element\` nor any of its
+			 * ancestors have the given class or the negated version of it, then the default activation will be returned.
 			 *
-			 * In the paradoxical situation where the closest ancestor contains __both__ the given class and the negated version
-			 * of it, the class is considered active.
+			 * In the paradoxical situation where the closest ancestor contains __both__ the given class and the negated
+			 * version of it, the class is considered active.
 			 *
 			 * @param {Element} element
 			 * @param {string} className
@@ -264,14 +264,14 @@ var Prism = (function (_self) {
 			/**
 			 * Creates a deep copy of the language with the given id and appends the given tokens.
 			 *
-			 * If a token in \`redef\` also appears in the copied language, then the existing token in the copied language will be
-			 * overwritten at its original position.
+			 * If a token in \`redef\` also appears in the copied language, then the existing token in the copied language
+			 * will be overwritten at its original position.
 			 *
 			 * ## Best practices
 			 *
-			 * Since the position of overwriting tokens (token in \`redef\` that overwrite tokens in the copied language) doesn't
-			 * matter, they can technically be in any order. However, this can be confusing to others that trying to understand
-			 * the language definition because, normally, the order of tokens matters in Prism grammars.
+			 * Since the position of overwriting tokens (token in \`redef\` that overwrite tokens in the copied language)
+			 * doesn't matter, they can technically be in any order. However, this can be confusing to others that trying
+			 * to understand the language definition because, normally, the order of tokens matters in Prism grammars.
 			 *
 			 * Therefore, it is encouraged to order overwriting tokens according to the positions of the overwritten tokens.
 			 * Furthermore, all non-overwriting tokens should be placed after the overwriting ones.
@@ -305,10 +305,10 @@ var Prism = (function (_self) {
 			 *
 			 * ## Usage
 			 *
-			 * This helper method makes it easy to modify existing languages. For example, the CSS language definition not only
-			 * defines CSS highlighting for CSS documents, but also needs to define highlighting for CSS embedded in HTML through
-			 * \`<style>\` elements. To do this, it needs to modify \`Prism.languages.markup\` and add the appropriate tokens.
-			 * However, \`Prism.languages.markup\` is a regular JavaScript object literal, so if you do this:
+			 * This helper method makes it easy to modify existing languages. For example, the CSS language definition not
+			 * only defines CSS highlighting for CSS documents, but also needs to define highlighting for CSS embedded in
+			 * HTML through \`<style>\` elements. To do this, it needs to modify \`Prism.languages.markup\` and add the
+			 * appropriate tokens. However, \`Prism.languages.markup\` is a regular JavaScript object literal, so if you do this:
 			 *
 			 * \`\`\`js
 			 * Prism.languages.markup.style = {
@@ -316,8 +316,8 @@ var Prism = (function (_self) {
 			 * };
 			 * \`\`\`
 			 *
-			 * Then the \`style\` token will be added (and processed) at the end. \`insertBefore\` allows you to insert tokens before
-			 * existing tokens. For the CSS example above, you would use it like this:
+			 * Then the \`style\` token will be added (and processed) at the end. \`insertBefore\` allows you to insert tokens
+			 * before existing tokens. For the CSS example above, you would use it like this:
 			 *
 			 * \`\`\`js
 			 * Prism.languages.insertBefore('markup', 'cdata', {
@@ -329,7 +329,8 @@ var Prism = (function (_self) {
 			 *
 			 * ## Special cases
 			 *
-			 * If the grammars of \`inside\` and \`insert\` have tokens with the same name, the tokens in \`inside\`'s grammar will be ignored.
+			 * If the grammars of \`inside\` and \`insert\` have tokens with the same name, the tokens in \`inside\`'s grammar
+			 * will be ignored.
 			 *
 			 * This behavior can be used to insert tokens after \`before\`:
 			 *
@@ -343,16 +344,16 @@ var Prism = (function (_self) {
 			 * ## Limitations
 			 *
 			 * The main problem \`insertBefore\` has to solve is iteration order. Since ES2015, the iteration order for object
-			 * properties is guaranteed to be the insertion order (except for integer keys) but some browsers behave differently
-			 * when keys are deleted and re-inserted. So \`insertBefore\` can't be implemented by temporarily deleting properties
-			 * which is necessary to insert at arbitrary positions.
+			 * properties is guaranteed to be the insertion order (except for integer keys) but some browsers behave
+			 * differently when keys are deleted and re-inserted. So \`insertBefore\` can't be implemented by temporarily
+			 * deleting properties which is necessary to insert at arbitrary positions.
 			 *
-			 * To solve this problem, \`insertBefore\` doesn't actually insert the given tokens into the target object. Instead, it
-			 * will create a new object and replace all references to the target object with the new one. This can be done
-			 * without temporarily deleting properties, so the iteration order is well-defined.
+			 * To solve this problem, \`insertBefore\` doesn't actually insert the given tokens into the target object.
+			 * Instead, it will create a new object and replace all references to the target object with the new one. This
+			 * can be done without temporarily deleting properties, so the iteration order is well-defined.
 			 *
-			 * However, only references that can be reached from \`Prism.languages\` or \`insert\` will be replaced. I.e. if you hold
-			 * the target object in a variable, then the value of the variable will not change.
+			 * However, only references that can be reached from \`Prism.languages\` or \`insert\` will be replaced. I.e. if you
+			 * hold the target object in a variable, then the value of the variable will not change.
 			 *
 			 * \`\`\`js
 			 * var oldMarkup = Prism.languages.markup;
@@ -364,11 +365,12 @@ var Prism = (function (_self) {
 			 *
 			 *
 			 *
-			 * @param {string} inside The property of \`root\` (e.g. a language id in \`Prism.languages\`) that contains the object
-			 *   to be modified.
+			 * @param {string} inside The property of \`root\` (e.g. a language id in \`Prism.languages\`) that contains the
+			 *   object to be modified.
 			 * @param {string} before The key to insert before.
 			 * @param {Grammar} insert An object containing the key-value pairs to be inserted.
-			 * @param {Object<string, any>} [root] The object containing \`inside\`, i.e. the object that contains the object to be modified.
+			 * @param {Object<string, any>} [root] The object containing \`inside\`, i.e. the object that contains the object
+			 *   to be modified.
 			 *
 			 * Defaults to \`Prism.languages\`.
 			 * @returns {Grammar} The new grammar object.
@@ -438,8 +440,8 @@ var Prism = (function (_self) {
 		plugins: {},
 
 		/**
-		 * This is the most high-level function in Prism’s API. It fetches all the elements that have a \`.language-xxxx\` class
-		 * and then calls {@link Prism.highlightElement} on each one of them.
+		 * This is the most high-level function in Prism’s API. It fetches all the elements that have a \`.language-xxxx\`
+		 * class and then calls {@link Prism.highlightElement} on each one of them.
 		 *
 		 * This is equivalent to \`Prism.highlightAllUnder(document, async, callback)\`.
 		 *
@@ -463,7 +465,8 @@ var Prism = (function (_self) {
 		 *
 		 * @memberof Prism
 		 * @param {ParentNode} container The root element, whose descendants that have a \`.language-xxxx\` class will be highlighted.
-		 * @param {boolean} [async=false] Whether each element is to be highlighted asynchronously using Web Workers. Default is \`false\`
+		 * @param {boolean} [async=false] Whether each element is to be highlighted asynchronously using Web Workers.
+		 *   Default is \`false\`
 		 * @param {HighlightCallback} [callback] An optional callback to be invoked on each element after its highlighting is done.
 		 * @public
 		 */
@@ -497,15 +500,15 @@ var Prism = (function (_self) {
 		 * 5. \`after-highlight\`
 		 * 6. \`complete\`
 		 *
-		 * Some the above hooks will be skipped if the element doesn't contain any text or there is no grammar loaded for the
-		 * element's language.
+		 * Some the above hooks will be skipped if the element doesn't contain any text or there is no grammar loaded for
+		 * the element's language.
 		 *
 		 * @memberof Prism
-		 * @param {Element} element The element containing the code. It must have a class of \`language-xxxx\` to be processed,
-		 *   where \`xxxx\` is a valid language identifier.
-		 * @param {boolean} [async=false] Whether the element is to be highlighted asynchronously using Web Workers to improve
-		 *   performance and avoid blocking the UI when highlighting very large chunks of code. This option is [disabled by
-		 *   default](https://prismjs.com/faq.html#why-is-asynchronous-highlighting-disabled-by-default).
+		 * @param {Element} element The element containing the code. It must have a class of \`language-xxxx\` to be
+		 *   processed, where \`xxxx\` is a valid language identifier.
+		 * @param {boolean} [async=false] Whether the element is to be highlighted asynchronously using Web Workers to
+		 *   improve performance and avoid blocking the UI when highlighting very large chunks of code. This option is
+		 *   [disabled by default](https://prismjs.com/faq.html#why-is-asynchronous-highlighting-disabled-by-default).
 		 *
 		 * Note: All language definitions required to highlight the code must be included in the main \`prism.js\` file for
 		 *   asynchronous highlighting to work. You can build your own bundle on the [Download
@@ -584,8 +587,8 @@ var Prism = (function (_self) {
 		},
 
 		/**
-		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input and the language
-		 * definitions to use, and returns a string with the HTML produced.
+		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input and the
+		 * language definitions to use, and returns a string with the HTML produced.
 		 *
 		 * The following hooks will be run:
 		 * 1. \`before-tokenize\`
@@ -617,8 +620,8 @@ var Prism = (function (_self) {
 		},
 
 		/**
-		 * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input and
-		 * the language definitions to use, and returns an array with the tokenized code.
+		 * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input
+		 * and the language definitions to use, and returns an array with the tokenized code.
 		 *
 		 * When the language definition includes nested tokens, the function is called recursively on each of these tokens.
 		 *

--- a/tests/__snapshots__/files/typeScript.js.shot
+++ b/tests/__snapshots__/files/typeScript.js.shot
@@ -60,18 +60,18 @@ class test {
    * Replaces text in a string, using a regular expression or search string.
    *
    * @param {string | RegExp} searchValue A string to search for.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-   *   string containing the text to replace for every successful match of
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   *   A string containing the text to replace for every successful match of
    *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-   *   string containing the text to replace for every successful match of
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   *   A string containing the text to replace for every successful match of
    *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   *   A_big_string_for_test string containing the text to replace for every
+   *   successful match of searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   *   A_big_string_for_test string containing the text to replace for every
+   *   successful match of searchValue in this string.
    * @returns {StarkStringType & NativeString}
    */
   replace(searchValue, replaceValue) {
@@ -80,18 +80,18 @@ class test {
        * Replaces text in a string, using a regular expression or search string.
        *
        * @param {string | RegExp} searchValue A string to search for.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-       *   string containing the text to replace for every successful match of
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       *   A string containing the text to replace for every successful match of
        *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-       *   string containing the text to replace for every successful match of
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       *   A string containing the text to replace for every successful match of
        *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       *   A_big_string_for_test string containing the text to replace for every
+       *   successful match of searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       *   A_big_string_for_test string containing the text to replace for every
+       *   successful match of searchValue in this string.
        * @returns {StarkStringType & NativeString}
        */
       testFunction() {}
@@ -165,18 +165,18 @@ class test {
    * Replaces text in a string, using a regular expression or search string.
    *
    * @param {string | RegExp} searchValue A string to search for.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-   *   string containing the text to replace for every successful match of
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   *   A string containing the text to replace for every successful match of
    *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-   *   string containing the text to replace for every successful match of
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   *   A string containing the text to replace for every successful match of
    *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   *   A_big_string_for_test string containing the text to replace for every
+   *   successful match of searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   *   A_big_string_for_test string containing the text to replace for every
+   *   successful match of searchValue in this string.
    * @returns {StarkStringType & NativeString}
    */
   replace(searchValue, replaceValue) {
@@ -185,18 +185,18 @@ class test {
        * Replaces text in a string, using a regular expression or search string.
        *
        * @param {string | RegExp} searchValue A string to search for.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-       *   string containing the text to replace for every successful match of
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       *   A string containing the text to replace for every successful match of
        *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-       *   string containing the text to replace for every successful match of
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       *   A string containing the text to replace for every successful match of
        *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       *   A_big_string_for_test string containing the text to replace for every
+       *   successful match of searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       *   A_big_string_for_test string containing the text to replace for every
+       *   successful match of searchValue in this string.
        * @returns {StarkStringType & NativeString}
        */
       testFunction() {}

--- a/tests/__snapshots__/files/typeScript.ts.shot
+++ b/tests/__snapshots__/files/typeScript.ts.shot
@@ -65,18 +65,18 @@ class test {
    * Replaces text in a string, using a regular expression or search string.
    *
    * @param {string | RegExp} searchValue A string to search for.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-   *   string containing the text to replace for every successful match of
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   *   A string containing the text to replace for every successful match of
    *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-   *   string containing the text to replace for every successful match of
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   *   A string containing the text to replace for every successful match of
    *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   *   A_big_string_for_test string containing the text to replace for every
+   *   successful match of searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   *   A_big_string_for_test string containing the text to replace for every
+   *   successful match of searchValue in this string.
    * @returns {StarkStringType & NativeString}
    */
   replace(searchValue: any, replaceValue: any) {
@@ -85,18 +85,18 @@ class test {
        * Replaces text in a string, using a regular expression or search string.
        *
        * @param {string | RegExp} searchValue A string to search for.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-       *   string containing the text to replace for every successful match of
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       *   A string containing the text to replace for every successful match of
        *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-       *   string containing the text to replace for every successful match of
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       *   A string containing the text to replace for every successful match of
        *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       *   A_big_string_for_test string containing the text to replace for every
+       *   successful match of searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       *   A_big_string_for_test string containing the text to replace for every
+       *   successful match of searchValue in this string.
        * @returns {StarkStringType & NativeString}
        */
       testFunction() {}

--- a/tests/__snapshots__/paragraph.test.js.snap
+++ b/tests/__snapshots__/paragraph.test.js.snap
@@ -58,9 +58,9 @@ exports[`code in description 1`] = `
  *     onResponderTerminate={this.touchableHandleResponderTerminate}
  *   >
  *     <View>
- *       Even though the hit detection/interactions are triggered by the wrapping
- *       (typically larger) node, we usually end up implementing custom logic that
- *       highlights this inner one.
+ *       Even though the hit detection/interactions are triggered by the
+ *       wrapping (typically larger) node, we usually end up implementing custom
+ *       logic that highlights this inner one.
  *     </View>
  *   </View>
  * );
@@ -265,15 +265,15 @@ exports[`description new line with dash 3`] = `
  * The test case file can either consist of two parts:
  *
  *     {source code}
- *     ----------------------------------------
+ *     -------------------------------------
  * {expected token stream}
  *
  * or of three parts:
  *
  *     {source code}
- *     ----------------------------------------
+ *     -------------------------------------
  * {expected token stream}
- *     ----------------------------------------
+ *     -------------------------------------
  * {text comment explaining the test case}
  *
  * If the file contains more than three parts, the remaining parts are just

--- a/tests/__snapshots__/typeScript.test.js.snap
+++ b/tests/__snapshots__/typeScript.test.js.snap
@@ -98,18 +98,18 @@ exports[`max width challenge 1`] = `
    * Replaces text in a string, using a regular expression or search string.
    *
    * @param {string | RegExp} searchValue A string to search for.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-   *   string containing the text to replace for every successful match of
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   *   A string containing the text to replace for every successful match of
    *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
-   * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-   *   string containing the text to replace for every successful match of
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   *   A string containing the text to replace for every successful match of
    *   searchValue in this string.
-   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-   *   string containing the text to replace for every successful match of searchValue in
-   *   this string.
+   * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+   *   A_big_string_for_test string containing the text to replace for every
+   *   successful match of searchValue in this string.
+   * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+   *   A_big_string_for_test string containing the text to replace for every
+   *   successful match of searchValue in this string.
    * @returns {StarkStringType & NativeString}
    */
   replace(searchValue, replaceValue) {
@@ -118,18 +118,18 @@ exports[`max width challenge 1`] = `
        * Replaces text in a string, using a regular expression or search string.
        *
        * @param {string | RegExp} searchValue A string to search for.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A
-       *   string containing the text to replace for every successful match of
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       *   A string containing the text to replace for every successful match of
        *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
-       * @param {string | (substring: string, ...args: any[]) => string} replaceValue A_big_string_for_test
-       *   string containing the text to replace for every successful match of
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       *   A string containing the text to replace for every successful match of
        *   searchValue in this string.
-       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test A_big_string_for_test
-       *   string containing the text to replace for every successful match of searchValue in
-       *   this string.
+       * @param {string | (substring: string, ...args: any[]) => string} replaceValue
+       *   A_big_string_for_test string containing the text to replace for every
+       *   successful match of searchValue in this string.
+       * @param {string | (substring: string, ...args: any[]) => string} A_big_string_for_test
+       *   A_big_string_for_test string containing the text to replace for every
+       *   successful match of searchValue in this string.
        * @returns {StarkStringType & NativeString}
        */
       testFunction() {}


### PR DESCRIPTION
This brings 2 changs:

1. `options.printWidth` is now the only print width. The print width will no longer be calculated by the functions doing the formatting. We now pass a new `options` object into these functions with a reduced `printWidth` instead.

2. Indentation is now calculated by counting the number of spaces and tabs before the comment. This count will then be converted into an indentation width (= indentation in spaces).

    However, there is one problem: tabs and spaces are counted in the original text. This means that the calculated indentation will only be correct if the indentation of the comment does not change.

    This problem can be seen in `prism-core.js`. All comments gain an additional indentation level which means that the indentation will be calculated incorrectly and `printWidth` will be too big (4 chars too big).

    To work around this issue, users can format their files twice. This issue only occurs if the indentation of a comment changes and the comment contains text that has to be wrapped.

    Note: this is not a new issue. The current version has the exact same issue.

    I do not know how to fix this.

---

This fixes #25.