### PR TITLE
fix: better trimming + refactor

### DIFF
--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -203,14 +203,14 @@ function formatDescription(
 
   text = text.replace(/^_+/g, "");
 
-  return text || "";
+  return text;
 }
 
 function breakDescriptionToLines(
   desContent: string,
   maxWidth: number,
   beginningSpace: string,
-) {
+): string {
   let str = desContent.trim();
 
   if (!str) {
@@ -241,30 +241,12 @@ function breakDescriptionToLines(
   return result;
 }
 
-function convertCommentDescToDescTag(parsed: Comment): void {
-  if (!parsed.description) {
-    return;
-  }
-
-  const Tag = parsed.tags.find(({ tag }) => tag.toLowerCase() === DESCRIPTION);
-  let { description = "" } = Tag || {};
-
-  description += parsed.description;
-
-  if (Tag) {
-    Tag.description = description;
-  } else {
-    parsed.tags.unshift({ tag: DESCRIPTION, description } as any);
-  }
-}
-
 export {
   EMPTY_LINE_SIGNATURE,
   NEW_LINE_START_WITH_DASH,
   NEW_PARAGRAPH_START_WITH_DASH,
   NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE,
   descriptionEndLine,
-  convertCommentDescToDescTag,
   FormatOptions,
   formatDescription,
 };

--- a/tests/__snapshots__/files/prism-core.js.shot
+++ b/tests/__snapshots__/files/prism-core.js.shot
@@ -740,7 +740,6 @@ var Prism = (function (_self) {
 		 *
 		 * @type {string}
 		 * @public
-		 *
 		 * @see GrammarToken
 		 */
 		this.type = type;
@@ -758,7 +757,6 @@ var Prism = (function (_self) {
 		 *
 		 * @type {string | string[]}
 		 * @public
-		 *
 		 * @see GrammarToken
 		 */
 		this.alias = alias;
@@ -866,7 +864,6 @@ var Prism = (function (_self) {
 
 	/**
 	 * @private
-	 *
 	 * @param {string} text
 	 * @param {LinkedList<string | Token>} tokenList
 	 * @param {any} grammar
@@ -1027,7 +1024,6 @@ var Prism = (function (_self) {
 
 	/**
 	 * @private
-	 *
 	 * @template T
 	 * @typedef LinkedListNode
 	 * @property {T} value
@@ -1037,7 +1033,6 @@ var Prism = (function (_self) {
 
 	/**
 	 * @private
-	 *
 	 * @template T
 	 */
 	function LinkedList() {

--- a/tests/__snapshots__/paragraph.test.js.snap
+++ b/tests/__snapshots__/paragraph.test.js.snap
@@ -248,7 +248,6 @@ exports[`description new line with dash 2`] = `
  *   able to share this cache between any \`ScrollMap\` view.
  *
  * @private
- *
  * @sideeffects
  */
 "


### PR DESCRIPTION
I originally intended to do a little refactoring but I noticed that some tests were fixed after I did some more whitespace timing.

Apart from extracting some behaviour into function and moving things around not much changed.

Changes:
- Synonyms will now be lowercased. E.g. `@ARG` -> `@arg` -> `@param`.
- The tag title, type, name, desc, and default value will now all be initialized to the empty string if undefined. If defined, they will be trimmed.
- `convertCommentDescToDescTag` now supports merging multiple `@description` tags. 
- Since the tag normalization (includes resolving synonyms) is now done before `convertCommentDescToDescTag`, `@desc` tags are now properly supported.
- The names of typeless alignable tags are no longer ignored. This fixes some potential alignment issues.