### PR TITLE
refactor: stringify

### DIFF
--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -1,7 +1,5 @@
 import { format } from "prettier";
-import { TAGS_NEED_FORMAT_DESCRIPTION } from "./roles";
 import { DESCRIPTION, EXAMPLE, TODO } from "./tags";
-import { Comment } from "comment-parser";
 import { JsdocOptions } from "./types";
 import { capitalizer } from "./utils";
 
@@ -39,6 +37,7 @@ function descriptionEndLine({
 
 interface FormatOptions {
   firstLinePrintWidth?: number;
+  extraIndentation?: boolean;
 }
 
 /**
@@ -48,19 +47,17 @@ interface FormatOptions {
  * @private
  */
 function formatDescription(
-  tag: string,
   text: string,
   options: JsdocOptions,
   formatOptions: FormatOptions = {},
 ): string {
-  if (!TAGS_NEED_FORMAT_DESCRIPTION.includes(tag)) {
-    return text;
-  }
-
   if (!text) return text;
 
   const { printWidth } = options;
-  const { firstLinePrintWidth = printWidth } = formatOptions;
+  const {
+    firstLinePrintWidth = printWidth,
+    extraIndentation = false,
+  } = formatOptions;
 
   /**
    * Description
@@ -118,10 +115,11 @@ function formatDescription(
 
   text = capitalizer(text);
 
-  text = `${"_".repeat(Math.max(0, printWidth - firstLinePrintWidth))}${text}`;
+  text =
+    "Z".repeat(Math.max(0, printWidth - firstLinePrintWidth - 1)) + " " + text;
 
   // Wrap tag description
-  const beginningSpace = tag === DESCRIPTION ? "" : "  "; // google style guide space
+  const beginningSpace = extraIndentation ? " ".repeat(2) : ""; // google style guide space
 
   text = text
     .split(NEW_PARAGRAPH_START_THREE_SPACE_SIGNATURE)
@@ -201,7 +199,7 @@ function formatDescription(
     }, "");
   }
 
-  text = text.replace(/^_+/g, "");
+  text = text.replace(/^Z+\b\s*/g, "");
 
   return text;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -162,10 +162,7 @@ export const getParser = (parser: Parser["parse"]) =>
 
       if (!content) {
         comment.value = "";
-      } else if (
-        countLines(content) === 1 &&
-        "/**  */".length + content.length <= commentSingleLineMaxWidth
-      ) {
+      } else if (countLines(content) === 1) {
         comment.value = `* ${content} `;
       } else {
         comment.value = "*\n" + prefixLinesWith(content, " * ") + "\n ";

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,5 +1,4 @@
 import { Tag } from "comment-parser";
-import { format, Options } from "prettier";
 import { formatDescription } from "./descriptionFormatter";
 import { DESCRIPTION, EXAMPLE, TODO } from "./tags";
 import {
@@ -14,191 +13,199 @@ import {
   trimIndentation,
   trimTrailingSpaces,
   prefixLinesWith,
+  tryFormat,
 } from "./utils";
+
+interface TagStringifyResult {
+  value: string;
+  insertLineBefore?: boolean;
+  insertLineAfter?: boolean;
+}
+function stringifyTag(
+  t: Tag,
+  alignment: AlignmentInfo,
+  options: JsdocOptions,
+): TagStringifyResult {
+  const { tag, description } = t;
+
+  if (tag === DESCRIPTION && !options.jsdocDescriptionTag) {
+    return stringifyCommentDescription(description, options);
+  } else if (tag === EXAMPLE) {
+    return stringifyExample(t, options);
+  } else {
+    return stringifyRegularTag(t, alignment, options);
+  }
+}
+function stringifyCommentDescription(
+  description: string,
+  options: JsdocOptions,
+): TagStringifyResult {
+  return {
+    value: formatDescription(description, options),
+    insertLineBefore: true,
+    insertLineAfter: true,
+  };
+}
+function stringifyExample(
+  { description }: Tag,
+  options: JsdocOptions,
+): TagStringifyResult {
+  let tagString = "@example";
+
+  const captionRegex = /^\s*<caption>([\s\S]*?)<\/caption>/i;
+  const exampleCaption = captionRegex.exec(description);
+  if (exampleCaption) {
+    description = description.slice(exampleCaption[0].length);
+    tagString += ` <caption>${exampleCaption[1].trim()}</caption>`;
+  }
+
+  description = trimIndentation(trimTrailingSpaces(description));
+
+  const EXAMPLE_CODE_INDENT = " ".repeat(2);
+
+  const examplePrintWith = options.printWidth - EXAMPLE_CODE_INDENT.length;
+
+  let formattedExample: string | undefined;
+
+  // try JSON formatting
+  if (formattedExample === undefined && /^\s*\{/.test(description)) {
+    formattedExample = tryFormat(description, {
+      ...options,
+      parser: "json",
+      printWidth: examplePrintWith,
+    });
+  }
+
+  // try current language formatting
+  if (formattedExample === undefined) {
+    formattedExample = tryFormat(description, {
+      ...options,
+      printWidth: examplePrintWith,
+    });
+  }
+
+  // unformatted
+  if (formattedExample === undefined) {
+    if (options.jsdocKeepUnParseAbleExampleIndent) {
+      formattedExample = description;
+    } else {
+      formattedExample = description
+        .split(/\n/g)
+        .map((line) => line.trim())
+        .join("\n");
+    }
+  }
+
+  // some formatters add empty lines
+  formattedExample = trimEmptyLines(formattedExample);
+
+  // add indentation
+  formattedExample = prefixLinesWith(
+    formattedExample,
+    EXAMPLE_CODE_INDENT,
+    true,
+  );
+
+  tagString += "\n" + formattedExample;
+
+  return {
+    value: tagString,
+    insertLineAfter: true,
+  };
+}
+function stringifyRegularTag(
+  { tag, type, name, description }: Tag,
+  { maxTypeOffset, maxNameOffset, maxDescOffset }: AlignmentInfo,
+  options: JsdocOptions,
+): TagStringifyResult {
+  let tagString = `@${tag}`;
+
+  const doAlign =
+    options.jsdocVerticalAlignment && TAGS_VERTICALLY_ALIGN_ABLE.includes(tag);
+  const addSpacesBefore = (element: "type" | "name" | "desc"): void => {
+    if (!doAlign) {
+      tagString += " ".repeat(options.jsdocSpaces);
+    } else {
+      if (element === "type") {
+        tagString = tagString.padEnd(maxTypeOffset);
+      } else if (element === "name") {
+        tagString = tagString.padEnd(maxNameOffset);
+      } else {
+        tagString = tagString.padEnd(maxDescOffset);
+      }
+    }
+  };
+
+  // add type
+  if (type) {
+    addSpacesBefore("type");
+    tagString += `{${type}}`;
+  }
+
+  // add name
+  if (name) {
+    addSpacesBefore("name");
+    tagString += name;
+  }
+
+  // add description
+  if (description) {
+    addSpacesBefore("desc");
+
+    if (!TAGS_NEED_FORMAT_DESCRIPTION.includes(tag)) {
+      tagString += description;
+    } else {
+      const extraIndentation = tag !== DESCRIPTION;
+      const extraIndentationStr = extraIndentation ? " ".repeat(2) : "";
+
+      /** The width (in spaces) of the line before the description. */
+      const beforeDescWidth = getLastLine(tagString).length;
+
+      if (beforeDescWidth >= options.printWidth) {
+        // the tag is already over printWidth -> add a line break
+        tagString +=
+          "\n" +
+          extraIndentationStr +
+          formatDescription(description, options, { extraIndentation });
+      } else {
+        // The description can potentially fit being appended to the current tag string
+        const formatted = formatDescription(description, options, {
+          firstLinePrintWidth: options.printWidth - beforeDescWidth,
+          extraIndentation,
+        });
+
+        const firstLine = getFirstLine(formatted);
+        if (!firstLine) {
+          // empty first line
+          tagString += formatted;
+        } else if (beforeDescWidth + firstLine.length <= options.printWidth) {
+          // formatted description fits within print width
+          tagString += formatted;
+        } else {
+          // first line is too long
+          tagString += "\n" + extraIndentationStr + formatted;
+        }
+      }
+    }
+  }
+
+  return {
+    value: tagString,
+    insertLineAfter: tag === TODO,
+  };
+}
 
 function stringifyCommentContent(
   groups: Tag[][],
   options: JsdocOptions,
 ): string {
-  const {
-    printWidth,
-    jsdocSpaces,
-    jsdocVerticalAlignment,
-    jsdocDescriptionTag,
-    jsdocKeepUnParseAbleExampleIndent,
-  } = options;
-
-  const shouldAlign = (tag: string) =>
-    jsdocVerticalAlignment && TAGS_VERTICALLY_ALIGN_ABLE.includes(tag);
-
-  interface TagStringifyResult {
-    value: string;
-    insertLineBefore?: boolean;
-    insertLineAfter?: boolean;
-  }
-  function stringifyTag(t: Tag, alignment: AlignmentInfo): TagStringifyResult {
-    const { tag, description } = t;
-
-    if (tag === DESCRIPTION && !jsdocDescriptionTag) {
-      return stringifyCommentDescription(description);
-    } else if (tag === EXAMPLE) {
-      return stringifyExample(description);
-    } else {
-      return stringifyOtherTag(t, alignment);
-    }
-  }
-  function stringifyCommentDescription(
-    description: string,
-  ): TagStringifyResult {
-    return {
-      value: formatDescription(description, options),
-      insertLineBefore: true,
-      insertLineAfter: true,
-    };
-  }
-  function stringifyExample(description: string): TagStringifyResult {
-    let tagString = "@example";
-
-    const captionRegex = /^\s*<caption>([\s\S]*?)<\/caption>/i;
-    const exampleCaption = captionRegex.exec(description);
-    if (exampleCaption) {
-      description = description.slice(exampleCaption[0].length);
-      tagString += ` <caption>${exampleCaption[1].trim()}</caption>`;
-    }
-
-    description = trimIndentation(trimTrailingSpaces(description));
-
-    const EXAMPLE_CODE_INDENT = " ".repeat(2);
-
-    const examplePrintWith = printWidth - EXAMPLE_CODE_INDENT.length;
-
-    let formattedExample: string | undefined;
-
-    // try JSON formatting
-    if (formattedExample === undefined && /^\s*\{/.test(description)) {
-      formattedExample = tryFormat(description, {
-        ...options,
-        parser: "json",
-        printWidth: examplePrintWith,
-      });
-    }
-
-    // try current language formatting
-    if (formattedExample === undefined) {
-      formattedExample = tryFormat(description, {
-        ...options,
-        printWidth: examplePrintWith,
-      });
-    }
-
-    // unformatted
-    if (formattedExample === undefined) {
-      if (jsdocKeepUnParseAbleExampleIndent) {
-        formattedExample = description;
-      } else {
-        formattedExample = description
-          .split(/\n/g)
-          .map((line) => line.trim())
-          .join("\n");
-      }
-    }
-
-    // some formatters add empty lines
-    formattedExample = trimEmptyLines(formattedExample);
-
-    // add indentation
-    formattedExample = prefixLinesWith(
-      formattedExample,
-      EXAMPLE_CODE_INDENT,
-      true,
-    );
-
-    tagString += "\n" + formattedExample;
-
-    return {
-      value: tagString,
-      insertLineAfter: true,
-    };
-  }
-  function stringifyOtherTag(
-    { tag, type, name, description }: Tag,
-    { maxTypeOffset, maxNameOffset, maxDescOffset }: AlignmentInfo,
-  ): TagStringifyResult {
-    let tagString = `@${tag}`;
-
-    const doAlign = shouldAlign(tag);
-    const withSpace = () => tagString.length + jsdocSpaces;
-    const getTypeOffset = () => (doAlign ? maxTypeOffset : withSpace());
-    const getNameOffset = () => (doAlign ? maxNameOffset : withSpace());
-    const getDescOffset = () => (doAlign ? maxDescOffset : withSpace());
-
-    const padLength = (length: number): void => {
-      tagString = tagString.padEnd(length, " ");
-    };
-
-    // add type
-    if (type) {
-      padLength(getTypeOffset());
-      tagString += `{${type}}`;
-    }
-
-    // add name
-    if (name) {
-      padLength(getNameOffset());
-      tagString += name;
-    }
-
-    // add description
-    if (description) {
-      if (!TAGS_NEED_FORMAT_DESCRIPTION.includes(tag)) {
-        padLength(getDescOffset());
-        tagString += description;
-      } else {
-        const extraIndentation = tag !== DESCRIPTION;
-        const extraIndentationStr = extraIndentation ? " ".repeat(2) : "";
-
-        const beforeDescWidth = doAlign
-          ? getDescOffset()
-          : getLastLine(tagString).length + jsdocSpaces;
-
-        if (beforeDescWidth >= printWidth) {
-          tagString +=
-            "\n" +
-            extraIndentationStr +
-            formatDescription(description, options, { extraIndentation });
-        } else {
-          const formatted = formatDescription(description, options, {
-            firstLinePrintWidth: printWidth - beforeDescWidth,
-            extraIndentation,
-          });
-
-          const firstLine = getFirstLine(formatted);
-          if (!firstLine) {
-            // empty first line
-            tagString += formatted;
-          } else if (beforeDescWidth + firstLine.length <= printWidth) {
-            // formatted description fits within print width
-            padLength(getDescOffset());
-            tagString += formatted;
-          } else {
-            // first line is too long
-            tagString += "\n" + extraIndentationStr + formatted;
-          }
-        }
-      }
-    }
-
-    return {
-      value: tagString,
-      insertLineAfter: tag === TODO,
-    };
-  }
-
   let result = "";
   let emptyLineAfter = false;
   groups.forEach((tags) => {
     const alignment = createAlignmentInfo(tags, options);
-    const stringifyResults = tags.map((tag) => stringifyTag(tag, alignment));
+    const stringifyResults = tags.map((tag) =>
+      stringifyTag(tag, alignment, options),
+    );
 
     // empty lines between groups
     stringifyResults[0].insertLineBefore = true;
@@ -226,14 +233,6 @@ function stringifyCommentContent(
   return trimEmptyLines(result);
 }
 
-function tryFormat(source: string, options?: Options): string | undefined {
-  try {
-    return format(source, options);
-  } catch (error) {
-    return undefined;
-  }
-}
-
 interface AlignmentInfo {
   readonly maxTypeOffset: number;
   readonly maxNameOffset: number;
@@ -252,18 +251,15 @@ function createAlignmentInfo(
     return EMPTY_ALIGNMENT_INFO;
   }
 
-  const shouldAlign = (tag: string) =>
-    jsdocVerticalAlignment && TAGS_VERTICALLY_ALIGN_ABLE.includes(tag);
-
-  tags = tags.filter(({ tag }) => shouldAlign(tag));
+  tags = tags.filter(({ tag }) => TAGS_VERTICALLY_ALIGN_ABLE.includes(tag));
 
   if (tags.length === 0) {
     return EMPTY_ALIGNMENT_INFO;
   }
 
-  const maxTag = Math.max(...tags.map((t) => (t.tag || "").length));
-  const maxType = Math.max(...tags.map((t) => (t.type || "").length));
-  const maxName = Math.max(...tags.map((t) => (t.name || "").length));
+  const maxTag = Math.max(...tags.map((t) => t.tag.length));
+  const maxType = Math.max(...tags.map((t) => t.type.length));
+  const maxName = Math.max(...tags.map((t) => t.name.length));
 
   const typeOff = "@".length + maxTag + jsdocSpaces;
   const nameOff = typeOff + (maxType ? maxType + "{}".length + jsdocSpaces : 0);

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -34,16 +34,6 @@ const TYPEDEF = "typedef";
 const VERSION = "version";
 const YIELDS = "yields";
 
-const SPACE_TAG_DATA = {
-  tag: "this_is_for_space",
-  name: "",
-  optional: false,
-  type: "",
-  description: "",
-  line: 0,
-  source: "",
-};
-
 export {
   ABSTRACT,
   ASYNC,
@@ -80,5 +70,4 @@ export {
   TYPEDEF,
   VERSION,
   YIELDS,
-  SPACE_TAG_DATA,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,18 +116,6 @@ function formatType(type: string, options?: Options): string {
   }
 }
 
-function addStarsToTheBeginningOfTheLines(comment: string): string {
-  if (numberOfAStringInString(comment.trim(), "\n") === 0) {
-    return `* ${comment.trim()} `;
-  }
-
-  return `*${comment.replace(/(\n(?!$))/g, "\n * ")}\n `;
-}
-
-function numberOfAStringInString(string: string, search: string | RegExp) {
-  return (string.match(new RegExp(search, "g")) || []).length;
-}
-
 // capitalize if needed
 function capitalizer(str: string): string {
   if (!str) {
@@ -181,10 +169,105 @@ function detectEndOfLine(text: string): "cr" | "crlf" | "lf" {
   }
 }
 
+function trimEmptyLines(string: string): string {
+  return string.replace(/^[\r\n]+|[\r\n]+$/g, "");
+}
+function trimTrailingSpaces(string: string): string {
+  return string
+    .split(/\n/g)
+    .map((line) => line.trimEnd())
+    .join("\n");
+}
+function trimIndentation(string: string): string {
+  const lines = string.split(/\n/g);
+
+  const enum IndentationKind {
+    SPACES,
+    TABS,
+    UNKNOWN,
+  }
+
+  let kind = IndentationKind.UNKNOWN;
+  let min = Infinity;
+
+  const skipFirst = !/^[ \t]/.test(lines[0]);
+  for (let i = skipFirst ? 1 : 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line) {
+      const first = line[0];
+
+      if (first === " ") {
+        if (kind === IndentationKind.TABS) {
+          break;
+        } else {
+          kind = IndentationKind.SPACES;
+        }
+      } else if (first === "\t") {
+        if (kind === IndentationKind.SPACES) {
+          break;
+        } else {
+          kind = IndentationKind.TABS;
+        }
+      } else {
+        min = 0;
+        break;
+      }
+
+      let lineIndent = 1;
+      for (let j = 1; j < line.length; j++) {
+        if (line[j] === first) {
+          lineIndent++;
+        } else {
+          break;
+        }
+      }
+
+      min = Math.min(min, lineIndent);
+    }
+  }
+
+  if (min === 0 || min === Infinity) {
+    return lines.join("\n");
+  } else {
+    return lines
+      .map((line, i) => (i === 0 && skipFirst ? line : line.slice(min)))
+      .join("\n");
+  }
+}
+
+function countLines(string: string): number {
+  return string.split(/\n/g).length;
+}
+function getFirstLine(string: string): string {
+  const lines = string.split(/\n/g);
+  return lines[0];
+}
+function getLastLine(string: string): string {
+  const lines = string.split(/\n/g);
+  return lines[lines.length - 1];
+}
+
+function prefixLinesWith(
+  string: string,
+  prefix: string,
+  ignoreEmpty?: boolean,
+): string {
+  return string
+    .split(/\n/g)
+    .map((line) => (ignoreEmpty && line.length === 0 ? "" : prefix + line))
+    .join("\n");
+}
+
 export {
   convertToModernType,
   formatType,
-  addStarsToTheBeginningOfTheLines,
   capitalizer,
   detectEndOfLine,
+  trimEmptyLines,
+  trimTrailingSpaces,
+  trimIndentation,
+  countLines,
+  getFirstLine,
+  getLastLine,
+  prefixLinesWith,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,6 +258,14 @@ function prefixLinesWith(
     .join("\n");
 }
 
+function tryFormat(source: string, options?: Options): string | undefined {
+  try {
+    return format(source, options);
+  } catch (error) {
+    return undefined;
+  }
+}
+
 export {
   convertToModernType,
   formatType,
@@ -270,4 +278,5 @@ export {
   getFirstLine,
   getLastLine,
   prefixLinesWith,
+  tryFormat,
 };

--- a/tests/__snapshots__/files/prism-core.js.shot
+++ b/tests/__snapshots__/files/prism-core.js.shot
@@ -278,11 +278,11 @@ var Prism = (function (_self) {
 			 *
 			 * @example
 			 *   Prism.languages['css-with-colors'] = Prism.languages.extend('css', {
-			 *     // Prism.languages.css already has a 'comment' token, so this token will overwrite CSS' 'comment' token
-			 *     // at its original position
-			 *     'comment': { ... },
-			 *     // CSS doesn't have a 'color' token, so this token will be appended
-			 *     'color': /\\\\b(?:red|green|blue)\\\\b/
+			 *       // Prism.languages.css already has a 'comment' token, so this token will overwrite CSS' 'comment' token
+			 *       // at its original position
+			 *       'comment': { ... },
+			 *       // CSS doesn't have a 'color' token, so this token will be appended
+			 *       'color': /\\\\b(?:red|green|blue)\\\\b/
 			 *   });
 			 *
 			 * @param {string} id The id of the language to extend. This has to be a key in \`Prism.languages\`.
@@ -464,10 +464,12 @@ var Prism = (function (_self) {
 		 * 3. All hooks of {@link Prism.highlightElement} for each element.
 		 *
 		 * @memberof Prism
-		 * @param {ParentNode} container The root element, whose descendants that have a \`.language-xxxx\` class will be highlighted.
+		 * @param {ParentNode} container
+		 *   The root element, whose descendants that have a \`.language-xxxx\` class will be highlighted.
 		 * @param {boolean} [async=false] Whether each element is to be highlighted asynchronously using Web Workers.
 		 *   Default is \`false\`
-		 * @param {HighlightCallback} [callback] An optional callback to be invoked on each element after its highlighting is done.
+		 * @param {HighlightCallback} [callback]
+		 *   An optional callback to be invoked on each element after its highlighting is done.
 		 * @public
 		 */
 		highlightAllUnder: function (container, async, callback) {
@@ -587,8 +589,8 @@ var Prism = (function (_self) {
 		},
 
 		/**
-		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input and the
-		 * language definitions to use, and returns a string with the HTML produced.
+		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input and the language
+		 * definitions to use, and returns a string with the HTML produced.
 		 *
 		 * The following hooks will be run:
 		 * 1. \`before-tokenize\`
@@ -620,8 +622,8 @@ var Prism = (function (_self) {
 		},
 
 		/**
-		 * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input
-		 * and the language definitions to use, and returns an array with the tokenized code.
+		 * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input and
+		 * the language definitions to use, and returns an array with the tokenized code.
 		 *
 		 * When the language definition includes nested tokens, the function is called recursively on each of these tokens.
 		 *

--- a/tests/__snapshots__/main.test.js.snap
+++ b/tests/__snapshots__/main.test.js.snap
@@ -19,7 +19,10 @@ exports[`Bad defined name 1`] = `
 "/** @type {import(\\"@jest/types/build/Config\\").InitialOptions} */
 /** @type {{ foo: string }} */
 
-/** @typedef {import(\\"@jest/types/build/Config\\").InitialOptions} name A description */
+/**
+ * @typedef {import(\\"@jest/types/build/Config\\").InitialOptions} name
+ *   A description
+ */
 "
 `;
 
@@ -100,7 +103,8 @@ exports[`Long description memory leak 1`] = `
  *   See {@link
  *   https://docs.microsoft.com/aspnet/core/signalr/configuration#configure-logging|the
  *   documentation for client logging configuration} for more details.
- * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
+ * @returns
+ *   The {@link @microsoft/signalr.HubConnectionBuilder} instance, for chaining.
  */
 "
 `;
@@ -134,11 +138,15 @@ exports[`Should align vertically param|property|returns|yields|throws if option 
 
 exports[`Should align vertically param|property|returns|yields|throws if option set to true, and amount of spaces is different than default 2`] = `
 "/**
- * @property    {Object}            unalginedProp     Unaligned property descriptin
- * @param       {String}            unalginedParam    Unaligned param description
+ * @property    {Object}            unalginedProp
+ *   Unaligned property descriptin
+ * @param       {String}            unalginedParam
+ *   Unaligned param description
  * @yields      {Number}                              Yields description
- * @returns     {String}                              Unaligned returns description
- * @throws      {CustomExceptio}                      Unaligned throws description
+ * @returns     {String}
+ *   Unaligned returns description
+ * @throws      {CustomExceptio}
+ *   Unaligned throws description
  */
 "
 `;

--- a/tests/__snapshots__/modern.test.js.snap
+++ b/tests/__snapshots__/modern.test.js.snap
@@ -6,7 +6,8 @@ exports[`convert array to modern type 1`] = `
  * @param {Adaptable} animNode
  * @param {object} InterpolationConfig
  * @param {ReadonlyArray<Adaptable>} InterpolationConfig.inputRange Like [0,1]
- * @param {string[]} InterpolationConfig.outputRange Like [\\"#0000ff\\",\\"#ff0000\\"]
+ * @param {string[]} InterpolationConfig.outputRange
+ *   Like [\\"#0000ff\\",\\"#ff0000\\"]
  * @param {import(\\"react-native-reanimated\\").default.Extrapolate} [InterpolationConfig.extrapolate]
  * @param {Foo<Bar>[]} arg1
  * @param {((item: Foo<Bar>) => Bar<number>)[] | number[] | string[]} arg2

--- a/tests/__snapshots__/singleTag.test.js.snap
+++ b/tests/__snapshots__/singleTag.test.js.snap
@@ -5,9 +5,7 @@ exports[`single tag 1`] = `
 function fun(param0) {}
 
 export const SubDomain = {
-  /**
-   * @returns {import(\\"axios\\").AxiosResponse<import(\\"../types\\").SubDomain>}
-   */
+  /** @returns {import(\\"axios\\").AxiosResponse<import(\\"../types\\").SubDomain>} */
   async subDomain(subDomainAddress) {},
 };
 "

--- a/tests/__snapshots__/singleTag.test.js.snap
+++ b/tests/__snapshots__/singleTag.test.js.snap
@@ -5,7 +5,9 @@ exports[`single tag 1`] = `
 function fun(param0) {}
 
 export const SubDomain = {
-  /** @returns {import(\\"axios\\").AxiosResponse<import(\\"../types\\").SubDomain>} */
+  /**
+   * @returns {import(\\"axios\\").AxiosResponse<import(\\"../types\\").SubDomain>}
+   */
   async subDomain(subDomainAddress) {},
 };
 "


### PR DESCRIPTION
I refactored the stringify code. It now clearly distinguishes the 3 formatting cases (description, example, regular tag).

Changes:
- `formatDescription` no longer decides which texts are formatted. Stringify now decides that.
- Stringify now creates the whole comment content (= comment value) instead of being called tag by tag.
- `SPACE_TAG_DATA` has been removed. Spacing between tags is now handled via the `insertLine{Before,After}` properties of a `TagStringifyResult`.
- A single-line JSDoc comment (e.g. `/** @type {number} */`) will now only be created if the comment length does not exceed `printWidth`.
- Alignment offsets are now calculated per group. This means that the properties of `@typedef`s can be aligned differently. I personally think this is better but I will revert it if wanted. Just tell me @hosseinmd.

There are also a few other changes that I will explain via comments in the test files.