### PR TITLE
refactor: minor changes

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -457,7 +457,7 @@ function combineIntoName({
   return {
     ...rest,
     name: name,
-    optional: false,
-    default: undefined,
+    optional: optional,
+    default: default_,
   };
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -154,7 +154,7 @@ export const getParser = (parser: Parser["parse"]) =>
           return tagGroup;
         })
         .map(addDefaultValueToDescription)
-        .map(combineIntoName)
+        .map(assignOptionalAndDefaultToName)
         .map(({ type, name, description, tag, ...rest }) => {
           const isVerticallyAlignAbleTags = TAGS_VERTICALLY_ALIGN_ABLE.includes(
             tag,
@@ -439,7 +439,7 @@ function addDefaultValueToDescription(
  * This will combine the `name`, `optional`, and `default` properties into name
  * setting the other two to `false` and `undefined` respectively.
  */
-function combineIntoName({
+function assignOptionalAndDefaultToName({
   name,
   optional,
   default: default_,


### PR DESCRIPTION
Changes:

- Some minor comment changes
- Added return type for `getParamsOrders`
- `getParamsOrders` is not longer for every tag group, it's only called once per comment now.
- I extracted some of the `map` function into two new functions and added documentation.