### PR TITLE
refactor: stringify

### DIFF
--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -18,23 +18,21 @@ const CODE = "2@^5!~#sdE!_CODE";
 interface DescriptionEndLineParams {
   description: string;
   tag: string;
-  isEndTag: boolean;
 }
 
 function descriptionEndLine({
   description,
   tag,
-  isEndTag,
-}: DescriptionEndLineParams): string {
-  if (description.trim().length < 0 || isEndTag) {
-    return "";
+}: DescriptionEndLineParams): boolean {
+  if (description.trim().length < 0) {
+    return false;
   }
 
   if ([DESCRIPTION, EXAMPLE, TODO].includes(tag)) {
-    return "\n";
+    return true;
   }
 
-  return "";
+  return false;
 }
 
 interface FormatOptions {

--- a/tests/__snapshots__/files/prism-core.js.shot
+++ b/tests/__snapshots__/files/prism-core.js.shot
@@ -587,8 +587,8 @@ var Prism = (function (_self) {
 		},
 
 		/**
-		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input and the
-		 * language definitions to use, and returns a string with the HTML produced.
+		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input and the language
+		 * definitions to use, and returns a string with the HTML produced.
 		 *
 		 * The following hooks will be run:
 		 * 1. \`before-tokenize\`
@@ -620,8 +620,8 @@ var Prism = (function (_self) {
 		},
 
 		/**
-		 * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input
-		 * and the language definitions to use, and returns an array with the tokenized code.
+		 * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input and
+		 * the language definitions to use, and returns an array with the tokenized code.
 		 *
 		 * When the language definition includes nested tokens, the function is called recursively on each of these tokens.
 		 *


### PR DESCRIPTION
This PR only has 1 goal: separation of concerns.

The current version of `stringify` not only has to stringify a single tag, it also has the responsibility of adding empty lines between tags. On the other hand, the _parser_ is responsible for joining the individual tag string together.

This PR changes that. Instead of stringifying a single tag, `stringify` will not stringify the whole comment content. This clearly separates concerns.

1. The parser no longer has to determine the max length of tag parts.
1. The parser no longer has to join tag strings to create the comment content.
2. The logic that stringifies a single tag no longer has to know the position of that tag in the comment (and the complete comment).
3. The logic that stringifies a single tag is no longer responsible for conditionally adding empty lines between tags.

The responsibilities are now split between 2 functions: `stringify` and `stringifyTag`.

`stringifyTag` only stringifies a single tag, nothing more. It only needs to know the tag, Prettier options, and the max lengths of tag parts.

`stringify` is responsible for creating the comment content. It takes a list of tags and Prettier options. It determines the max lengths of tag parts and the empty lines between tags.

---

_Why did the snapshots change?_
Because this fixes a bug. [This `\n` right here](https://github.com/hosseinmd/prettier-plugin-jsdoc/blob/4a9cbd2e21ba3be56862adb3e75b86c48a1e329d/src/stringify.ts#L17) causes [this length](https://github.com/hosseinmd/prettier-plugin-jsdoc/blob/4a9cbd2e21ba3be56862adb3e75b86c48a1e329d/src/stringify.ts#L73) to be 1 character to much. Since the new `stringifyTag` is not responsible for adding `\n`s, it doesn't have this problem.