### PR TITLE
fix: editorconfig indent_style=tab breaking example tag

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -223,12 +223,7 @@ function formatCode(
       .every((v) => !v.trim() || v.startsWith(beginningSpace))
   ) {
     result = result.replace(
-      new RegExp(
-        `\n${beginningSpace
-          .replace(/[\t]/g, "[\\t]")
-          .replace(/[^S\r\n]/g, "[^S\\r\\n]")}`,
-        "g",
-      ),
+      new RegExp(`\n${beginningSpace.replace(/[\t]/g, "[\\t]")}`, "g"),
       "\n",
     );
   }

--- a/tests/__snapshots__/main.test.ts.snap
+++ b/tests/__snapshots__/main.test.ts.snap
@@ -374,6 +374,16 @@ exports[`example  1`] = `
 "
 `;
 
+exports[`example with tab intention 1`] = `
+"/**
+ * @example
+ * 	function Hello() {
+ * 		console.log(\\"Hello World\\");
+ * 	}
+ */
+"
+`;
+
 exports[`jsdoc tags 1`] = `
 "/**
  * @namespace

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -626,3 +626,31 @@ test("example ", () => {
 
   expect(subject(subject(result2))).toMatchSnapshot();
 });
+
+test("example with tab intention", () => {
+  const result2 = subject(
+    `
+/**
+ * @example
+ * 	function Hello() {
+ * 		console.log("Hello World");
+ * 	}
+ */
+    
+`,
+    {
+      useTabs: true,
+    },
+  );
+
+  expect(
+    subject(
+      subject(result2, {
+        useTabs: true,
+      }),
+      {
+        useTabs: true,
+      },
+    ),
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
Closes https://github.com/hosseinmd/prettier-plugin-jsdoc/issues/109

All tests pass I'm not sure if by removing this match in the regexp somethings breaks. Can you confirm on the intent of this part of the regexp @hosseinmd?

Also didn't add any extra tests because wasn't sure how to add an editorconfig in a folder with the test file in the current configuration, however I did test it in a sandbox and seems to be working