### PR TITLE
chore(deps): bump comment-parser from 1.1.4 to 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "binary-search-bounds": "^2.0.5",
-    "comment-parser": "^1.1.4",
+    "comment-parser": "^1.2.4",
     "linguist-languages": "^7.13.0",
     "mdast-util-from-markdown": "^0.8.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,10 +1709,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comment-parser@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.4.tgz#38ba3fb9293e29fa613a287f1fe184241dbd3755"
-  integrity sha512-MrWw1IrmmeCMLJKA8SvMw0tImTd4BHBFQ4WCNxzZoNeWaDL7OAXugF3BIKY042wNsNzGqD5liCgpQS99cuY1qA==
+comment-parser@^1.2.4:
+  version "1.2.4"
+  resolved "https://mirrors.tencent.com/npm/comment-parser/-/comment-parser-1.2.4.tgz#489f3ee55dfd184a6e4bffb31baba284453cb760"
+  integrity sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==
 
 commitlint@^12.0.1:
   version "12.0.1"


### PR DESCRIPTION
Upgrade `comment-parse` to be compatible with node15.

See also [the issue](https://github.com/syavorsky/comment-parser/issues/141)