### PR TITLE
feat: add option to turn off capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Description is formatting as Markdown, so you could use any features of Markdown
 | jsdocKeepUnParseAbleExampleIndent | Boolean | false     |
 | jsdocSingleLineComment            | Boolean | true      |
 | jsdocSeparateReturnsFromParam     | Boolean | fales     | Add an space between last @param and @returns                                             |
+| jsdocCapitalizeDescription        | Boolean | true      |
 | tsdoc                             | Boolean | false     |
 | jsdocPrintWidth                   | Number  | undefined | If You don't set value to jsdocPrintWidth, the printWidth will be use as jsdocPrintWidth. |
 

--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -71,7 +71,7 @@ function formatDescription(
     tables.push(code);
     return `\n\n${TABLE}\n\n${_3 ? _3.slice(1) : ""}`;
   });
-  text = capitalizer(text);
+  if (options.jsdocCapitalizeDescription) text = capitalizer(text);
 
   text = `${"!".repeat(tagStringLength)}${
     text.startsWith("```") ? "\n" : ""
@@ -221,7 +221,8 @@ function formatDescription(
 
               _paragraph = _paragraph.replace(/\s+/g, " "); // Make single line
 
-              _paragraph = capitalizer(_paragraph);
+              if (options.jsdocCapitalizeDescription)
+                _paragraph = capitalizer(_paragraph);
               if (options.jsdocDescriptionWithDot)
                 _paragraph = _paragraph.replace(/([\w\p{L}])$/u, "$1."); // Insert dot if needed
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,13 @@ const options: Record<keyof JsdocOptions, SupportOption> = {
     default: false,
     description: "Add an space between last @param and @returns",
   },
+  jsdocCapitalizeDescription: {
+    name: "jsdocCapitalizeDescription",
+    type: "boolean",
+    category: "jsdoc",
+    default: true,
+    description: "Should capitalize first letter of description",
+  },
   tsdoc: {
     name: "tsdoc",
     type: "boolean",
@@ -84,6 +91,8 @@ const defaultOptions: JsdocOptions = {
     .default as boolean,
   jsdocSingleLineComment: options.jsdocSingleLineComment.default as boolean,
   jsdocSeparateReturnsFromParam: options.jsdocSeparateReturnsFromParam
+    .default as boolean,
+  jsdocCapitalizeDescription: options.jsdocCapitalizeDescription
     .default as boolean,
   tsdoc: options.tsdoc.default as boolean,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface JsdocOptions {
   /** default is true */
   jsdocSingleLineComment: boolean;
   jsdocSeparateReturnsFromParam: boolean;
+  jsdocCapitalizeDescription: boolean;
   tsdoc: boolean;
 }
 


### PR DESCRIPTION
Hello!

This plugin is exactly what I need, except for one little detail: It runs into some false positives when trying to capitalize descriptions. Rather than adding more exceptions, the only one currently being links starting with `http(s)://`, I propose an option called `jsdocCapitalizeDescription` that would enable users to turn off capitalization altogether.