### PR TITLE
fix: support being called as a built-in parser

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -27,9 +27,11 @@ import { SPACE_TAG_DATA } from "./tags";
 export const getParser = (originalParse: Parser["parse"], parserName: string) =>
   function jsdocParser(
     text: string,
-    parsers: Parameters<Parser["parse"]>[1],
-    options: AllOptions,
+    parsersOrOptions: Parameters<Parser["parse"]>[1],
+    maybeOptions?: AllOptions,
   ): AST {
+  const parsers = parsersOrOptions;
+  let options = (maybeOptions ?? parsersOrOptions) as AllOptions;
     const prettierParse =
       findPluginByParser(parserName, options)?.parse || originalParse;
 


### PR DESCRIPTION
This should close https://github.com/facebook/jest/issues/12049

Obviously it's not the most ideal - I don't really know of a good way to test this given that it seems very situational :/

It should be possible to make it more TypeScript friendly by breaking the `jsdocParser` function out to the top level so that function overrides could be used to type the parameters, but that would be a larger change.