### PR TITLE
fix: add a package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prettier-plugin-jsdoc",
   "version": "0.3.30",
-  "description": "",
+  "description": "A Prettier plugin to format JSDoc comments.",
   "private": false,
   "workspaces": {
     "prettier-plugin-fake": "./prettier-plugin-fake"


### PR DESCRIPTION
Adds a package description to the `package.json` `description` field, which is currently empty. This will get used all sorts of contexts, the most obvious being in the search results on [npmjs.com](https://www.npmjs.com):

https://www.npmjs.com/search?q=prettier-plugin-jsdoc

<img width="482" alt="Screen Shot 2021-11-13 at 1 44 07 pm" src="https://user-images.githubusercontent.com/1754873/141602997-04cd5f4e-79ee-464b-af61-bbcb3334db38.png">

After this PR is published a proper description should appear instead of the first characters of the readme.
