### PR TITLE
fix: ensure formatting matches Prettier markdown formatter

### DIFF
--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -303,7 +303,7 @@ function formatDescription(
         }
 
         if (ast.type === "emphasis") {
-          return `*${stringyfy(ast, intention, mdAst)}*`;
+          return `_${stringyfy(ast, intention, mdAst)}_`;
         }
 
         if (ast.type === "heading") {

--- a/tests/__snapshots__/descriptions.test.ts.snap
+++ b/tests/__snapshots__/descriptions.test.ts.snap
@@ -661,7 +661,7 @@ exports[`description new line with dash 3`] = `
 exports[`description start underscores 1`] = `
 "/**
  * @param {string} a **very** important!
- * @param {string} b *less* important...
+ * @param {string} b _less_ important...
  */
 "
 `;
@@ -673,6 +673,35 @@ exports[`empty lines 1`] = `
  * Bar
  *
  * @param a Baz
+ */
+"
+`;
+
+exports[`matches prettier markdown format 1`] = `
+"/**
+ * # Header
+ *
+ * _Look,_ code blocks are formatted _too!_
+ *
+ * \`\`\`js
+ * function identity(x) {
+ *   return x;
+ * }
+ * \`\`\`
+ *
+ * Pilot|Airport|Hours --|:--:|--: John Doe|SKG|1338 Jane Roe|JFK|314
+ *
+ * - List
+ * - With a [link] (/to/somewhere)
+ * - And another oneExample title
+ *
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur
+ * consectetur maximus risus, sed maximus tellus tincidunt et.
+ *
+ * @param {string} a **very** important!
+ * @param {string} b _less_ important...
+ * @param {string} a **very** important!
+ * @param {string} b _less_ important...
  */
 "
 `;

--- a/tests/__snapshots__/files/prism-core.js.shot
+++ b/tests/__snapshots__/files/prism-core.js.shot
@@ -51,7 +51,7 @@ var Prism = (function (_self) {
 		/**
 		 * A namespace for utility methods.
 		 *
-		 * All function in this namespace that are not explicitly marked as *public* are for **internal use only** and may
+		 * All function in this namespace that are not explicitly marked as _public_ are for **internal use only** and may
 		 * change or disappear at any time.
 		 *
 		 * @memberof Prism
@@ -219,7 +219,7 @@ var Prism = (function (_self) {
 			 * Returns whether a given class is active for \`element\`.
 			 *
 			 * The class can be activated if \`element\` or one of its ancestors has the given class and it can be deactivated
-			 * if \`element\` or one of its ancestors has the negated version of the given class. The *negated version* of the
+			 * if \`element\` or one of its ancestors has the negated version of the given class. The _negated version_ of the
 			 * given class is just the given class with a \`no-\` prefix.
 			 *
 			 * Whether the class is active is determined by the closest ancestor of \`element\` (where \`element\` itself is
@@ -299,7 +299,7 @@ var Prism = (function (_self) {
 			},
 
 			/**
-			 * Inserts tokens *before* another token in a language definition or any other grammar.
+			 * Inserts tokens _before_ another token in a language definition or any other grammar.
 			 *
 			 * ## Usage
 			 *

--- a/tests/descriptions.test.ts
+++ b/tests/descriptions.test.ts
@@ -487,6 +487,45 @@ test("printWidth", () => {
   expect(result1).toMatchSnapshot();
 });
 
+test("matches prettier markdown format", () => {
+  const result1 = subject(
+    `/**
+ * Header
+ * ======
+ *
+ * _Look,_ code blocks are formatted *too!*
+ *
+ * \`\`\` js
+ * function identity(x) { return x }
+ * \`\`\`
+ *
+ * Pilot|Airport|Hours
+ * --|:--:|--:
+ * John Doe|SKG|1338
+ * Jane Roe|JFK|314
+ *
+ * - - - - - - - - - - - - - - -
+ *
+ * + List
+ *  + with a [link] (/to/somewhere)
+ * + and [another one]
+ *
+ *
+ *   [another one]:  http://example.com 'Example title'
+ *
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+ * Curabitur consectetur maximus risus, sed maximus tellus tincidunt et.
+ *
+ * @param {string} a __very__ important!
+ * @param {string} b _less_ important...
+ * @param {string} a __very__ important!
+ * @param {string} b *less* important...
+ */`,
+  );
+
+  expect(result1).toMatchSnapshot();
+})
+
 test("description start underscores", () => {
   const result1 = subject(
     `/**


### PR DESCRIPTION
Fixes #142

Have also added a test using the sample markdown the Prettier playground uses, to ensure the formatting remains consistent.