### PR TITLE
fix: line breaks inside jsdoc link synonyms

### DIFF
--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -257,11 +257,11 @@ function formatDescription(
               const links: string[] = [];
               // Find jsdoc links and remove spaces
               _paragraph = _paragraph.replace(
-                /{@link[\s](([^{}])*)}/g,
-                (_, link: string) => {
+                /{@(link|linkcode|linkplain)[\s](([^{}])*)}/g,
+                (_, tag: string, link: string) => {
                   links.push(link);
 
-                  return `{@link${"_".repeat(link.length)}}`;
+                  return `{@${tag}${"_".repeat(link.length)}}`;
                 },
               );
 
@@ -280,13 +280,13 @@ function formatDescription(
 
               // Replace links
               result = result.replace(
-                /{@link([_]+)}/g,
-                (original: string, underline: string) => {
+                /{@(link|linkcode|linkplain)([_]+)}/g,
+                (original: string, tag: string, underline: string) => {
                   const link = links[0];
 
                   if (link.length === underline.length) {
                     links.shift();
-                    return `{@link ${link}}`;
+                    return `{@${tag} ${link}}`;
                   }
 
                   return original;

--- a/tests/__snapshots__/descriptions.test.ts.snap
+++ b/tests/__snapshots__/descriptions.test.ts.snap
@@ -127,6 +127,55 @@ export function difference<T>(first: Set<T>, second: Set<T>): Set<T>;
 "
 `;
 
+exports[`Jsdoc link synonyms in description 1`] = `
+"/**
+ * Calculate the
+ * {@linkcode https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between two sets.
+ *
+ * @param second
+ * @param first
+ */
+export function difference<T>(first: Set<T>, second: Set<T>): Set<T>;
+
+/**
+ * Calculate the
+ * {@linkcode https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * {@linkcode https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between two sets.
+ */
+
+/**
+ * Calculate the
+ * {@linkcode https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between {@linkcode https://en.wikipedia.org/wiki/Complement} between two sets.
+ */
+
+/**
+ * Calculate the
+ * {@linkplain https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between two sets.
+ *
+ * @param second
+ * @param first
+ */
+export function difference<T>(first: Set<T>, second: Set<T>): Set<T>;
+
+/**
+ * Calculate the
+ * {@linkplain https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * {@linkplain https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between two sets.
+ */
+
+/**
+ * Calculate the
+ * {@linkplain https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between {@linkplain https://en.wikipedia.org/wiki/Complement} between two sets.
+ */
+"
+`;
+
 exports[`Jsx tsx css  1`] = `
 "/**
  * \`\`\`js

--- a/tests/descriptions.test.ts
+++ b/tests/descriptions.test.ts
@@ -805,6 +805,61 @@ test("Jsdoc link in description", () => {
   expect(result1).toMatchSnapshot();
 });
 
+test("Jsdoc link synonyms in description", () => {
+  const result1 = subject(`
+/**
+ * Calculate the 
+ * {@linkcode https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between two sets.
+ * @param second
+ * @param first
+ */
+ export function difference<T>(first: Set<T>, second: Set<T>): Set<T>
+
+
+ /**
+ * Calculate the 
+ * {@linkcode https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * {@linkcode https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between two sets.
+ */
+
+  /**
+ * Calculate the 
+ * {@linkcode https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between
+ * {@linkcode https://en.wikipedia.org/wiki/Complement}
+ * between two sets.
+ */
+
+  /**
+ * Calculate the 
+ * {@linkplain https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between two sets.
+ * @param second
+ * @param first
+ */
+ export function difference<T>(first: Set<T>, second: Set<T>): Set<T>
+
+
+ /**
+ * Calculate the 
+ * {@linkplain https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * {@linkplain https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between two sets.
+ */
+
+  /**
+ * Calculate the 
+ * {@linkplain https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement difference}
+ * between
+ * {@linkplain https://en.wikipedia.org/wiki/Complement}
+ * between two sets.
+ */`);
+
+  expect(result1).toMatchSnapshot();
+});
+
 test("Markdown link", () => {
   const result1 = subject(`
 /**


### PR DESCRIPTION
Fixes #148.
Changes referred to https://github.com/hosseinmd/prettier-plugin-jsdoc/commit/86bb75c55f6894b2387f4f6b0de7207df86004ef.