### PR TITLE
Reduce package size

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,20 @@
+import path from "path";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 
+// ignore all bare imports from node_modules
+// which are not relative and not absolute
+const external = (id) =>
+  id.startsWith(".") === false && path.isAbsolute(id) === false;
+
 export default {
-  input: "dist/index.js",
+  input: "./dist/index.js",
   output: {
     file: "dist/index.js",
     format: "commonjs",
   },
-  external: ["prettier", "comment-parser", "binary-searching"],
+  external,
   plugins: [
     commonjs({}),
     nodeResolve({}),


### PR DESCRIPTION
Just found the size of this package is quite huge, ~17MB.
https://packagephobia.com/result?p=prettier-plugin-jsdoc

This is because all prettier parsers are bundled with plugin sources.
This is because external array skips exact matches. Though imports like
`prettier/parser-typescript` are included which resulted in huge bundle
size.

With this chagen we see great size reduction
```
   1886 Apr 27 19:18 index.d.ts
  45690 Apr 27 19:18 index.js
  19076 Apr 27 19:18 index.min.mjs
  50735 Apr 27 19:18 index.umd.js
  18920 Apr 27 19:18 index.umd.min.js
```

Build time is down from 168s to 7s

cc @hosseinmd 