### PR TITLE
Avoid breaking inline code blocks

### DIFF
--- a/script.mjs
+++ b/script.mjs
@@ -1,17 +1,17 @@
-import { execSync } from "child_process";
 import { default as chalk } from "chalk";
+import { execSync } from "child_process";
 
 const __TEST__ = process.argv.includes("--test");
 
 function $(commands) {
   if (typeof commands === "string") {
     console.log(chalk.gray("$", commands));
-    return execSync(commands).toString();
+    return execSync(commands, { stdio: "inherit" });
   }
 
   return commands.map((command) => {
     console.log(chalk.gray("$", commands));
-    execSync(command).toString();
+    execSync(command, { stdio: "inherit" });
   });
 }
 

--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -269,7 +269,7 @@ function formatDescription(
                   (_, tag: string, link: string) => {
                     links.push(link);
 
-                    return `{@${tag}${"_".repeat(link.length)}}`;
+                    return `{@${tag}${"<".repeat(link.length)}}`;
                   },
                 );
 
@@ -287,12 +287,11 @@ function formatDescription(
                   _paragraph,
                   printWidth,
                   intention,
-                  tsdoc,
                 );
 
                 // Replace links
                 result = result.replace(
-                  /{@(link|linkcode|linkplain)([_]+)}/g,
+                  /{@(link|linkcode|linkplain)([<]+)}/g,
                   (original: string, tag: string, underline: string) => {
                     const link = links[0];
 
@@ -362,48 +361,20 @@ function breakDescriptionToLines(
   desContent: string,
   maxWidth: number,
   beginningSpace: string,
-  doNotBreakInlineCode = false,
 ): string {
-  let str = desContent.trim();
+  const formatted = format(desContent, {
+    printWidth: maxWidth,
+    parser: "markdown",
+    proseWrap: "always",
+  });
 
-  if (!str) {
-    return str;
-  }
+  const output = formatted
+    .split("\n")
+    .map((l) => beginningSpace + l)
+    .join("\n")
+    .trimEnd();
 
-  let result = "";
-  while (str.length > maxWidth) {
-    let sliceIndex = str.lastIndexOf(
-      " ",
-      str.startsWith("\n") ? maxWidth + 1 : maxWidth,
-    );
-    // do not break inline code blocks (`)
-    if (
-      doNotBreakInlineCode &&
-      str.slice(0, sliceIndex).split("`").length % 2 === 0
-    ) {
-      sliceIndex += str.slice(sliceIndex).indexOf("`") + 1;
-    }
-
-    /**
-     * When a str is a long word lastIndexOf will gives 4 every time loop
-     * running unlimited time
-     */
-    if (sliceIndex <= beginningSpace.length)
-      sliceIndex = str.indexOf(" ", beginningSpace.length + 1);
-
-    if (sliceIndex === -1) sliceIndex = str.length;
-
-    result += str.substring(0, sliceIndex);
-    str = str.substring(sliceIndex + 1);
-    if (str) {
-      str = `${beginningSpace}${str}`;
-      str = `\n${str}`;
-    }
-  }
-
-  result += str;
-
-  return `${beginningSpace}${result}`;
+  return output;
 }
 
 export { descriptionEndLine, FormatOptions, formatDescription };

--- a/src/descriptionFormatter.ts
+++ b/src/descriptionFormatter.ts
@@ -69,7 +69,7 @@ function formatDescription(
 ): string {
   if (!text) return text;
 
-  const { printWidth } = options;
+  const { printWidth, tsdoc } = options;
   const { tagStringLength = 0, beginningSpace } = formatOptions;
 
   /**
@@ -287,6 +287,7 @@ function formatDescription(
                   _paragraph,
                   printWidth,
                   intention,
+                  tsdoc,
                 );
 
                 // Replace links
@@ -361,6 +362,7 @@ function breakDescriptionToLines(
   desContent: string,
   maxWidth: number,
   beginningSpace: string,
+  doNotBreakInlineCode = false,
 ): string {
   let str = desContent.trim();
 
@@ -374,6 +376,14 @@ function breakDescriptionToLines(
       " ",
       str.startsWith("\n") ? maxWidth + 1 : maxWidth,
     );
+    // do not break inline code blocks (`)
+    if (
+      doNotBreakInlineCode &&
+      str.slice(0, sliceIndex).split("`").length % 2 === 0
+    ) {
+      sliceIndex += str.slice(sliceIndex).indexOf("`") + 1;
+    }
+
     /**
      * When a str is a long word lastIndexOf will gives 4 every time loop
      * running unlimited time

--- a/tests/__snapshots__/descriptions.test.ts.snap
+++ b/tests/__snapshots__/descriptions.test.ts.snap
@@ -363,7 +363,7 @@ exports[`New Lines with star 2`] = `
 `;
 
 exports[`New line with \\ 1`] = `
-"/** A short description, * A long description. */
+"/** A short description, \\\\* A long description. */
 "
 `;
 
@@ -372,8 +372,8 @@ exports[`Non-english description with dot 1`] = `
  * Wir brauchen hier eine effizientere Lösung. Die generierten Dateien sind zu
  * groß.
  *
- * Wir brauchen hier eine effizientere Lösung. Die generierten Dateien sind zu
- * 3434.
+ * Wir brauchen hier eine effizientere Lösung. Die generierten Dateien sind
+ * zu 3434.
  *
  * Wir brauchen hier eine effizientere Lösung. Die generierten Dateien sind zu
  * groß.
@@ -401,7 +401,9 @@ exports[`Non-english description with dot 1`] = `
  */
 
 /**
- * Unicode（ユニコード）は、符号化文字集合や文字符号化方式などを定めた、文字コードの業界規格。文字集合（文字セット）が単一の大規模文字セットであること（「Uni」という名はそれに由来する）などが特徴である.
+ * Unicode（ユニコード）は、符号化文字集合や文字符号化方式などを定めた、文字コー
+ * ドの業界規格。文字集合（文字セット）が単一の大規模文字セットであること（
+ * 「Uni」という名はそれに由来する）などが特徴である.
  *
  * @see https://ja.wikipedia.org/wiki/Unicode
  */
@@ -509,9 +511,9 @@ exports[`code in description 1`] = `
  * \`\`\`
  *
  * - Choose the rendered component who's touches should start the interactive
- *   sequence. On that rendered node, forward all \`Touchable\` responder
- *   handlers. You can choose any rendered node you like. Choose a node whose
- *   hit target you'd like to instigate the interaction sequence:
+ *   sequence. On that rendered node, forward all \`Touchable\` responder handlers.
+ *   You can choose any rendered node you like. Choose a node whose hit target
+ *   you'd like to instigate the interaction sequence:
  *
  * \`\`\`js
  * // In render function:
@@ -688,10 +690,9 @@ exports[`description new line with dash 1`] = `
  * - Stop a scroll mid-bounce at the top, continue pulling to have the outer
  *   view dismiss.
  * - However, without catching the scroll view mid-bounce (while it is
- *   motionless), if you drag far enough for the scroll view to become
- *   responder (and therefore drag the scroll view a bit), any backswipe
- *   navigation of a swipe gesture higher in the view hierarchy, should be
- *   rejected.
+ *   motionless), if you drag far enough for the scroll view to become responder
+ *   (and therefore drag the scroll view a bit), any backswipe navigation of a
+ *   swipe gesture higher in the view hierarchy, should be rejected.
  */
 function scrollResponderHandleTerminationRequest() {
   return !this.state.observedScrollSinceBecomingResponder;
@@ -883,14 +884,13 @@ exports[`numbers and code in description 3`] = `
  * used:
  *
  * 1. A keydown event occurred lorem ipsum dolor sit amet, consectetur adipiscing
- *    elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
- *    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+ *    elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+ *    enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
  *    aliqimmediately before a focus event;
  * 2. A focus evenlorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
- *    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
- *    minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqt
- *    happened on an element which requires keyboard interaction (e.g., a text
- *    field);
+ *    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+ *    veniam, quis nostrud exercitation ullamco laboris nisi ut aliqt happened on
+ *    an element which requires keyboard interaction (e.g., a text field);
  *
  * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
  * tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -910,19 +910,18 @@ exports[`numbers and code in description 4`] = `
  * mollis sed, nonummy id, metus.
  *
  * 1. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
- *    ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
- *    dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies
- *    nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.
+ *    ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis
+ *    parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
+ *    pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.
  * 2. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim
- *    justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum
- *    felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus
- *    elementum semper nisi. Aenean vulputate eleifend tellus.
+ *    justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis
+ *    eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum
+ *    semper nisi. Aenean vulputate eleifend tellus.
  *
  *    Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam
  *    lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra
  *    nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam
- *    ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget
- *    dui.
+ *    ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui.
  *
  * @public
  */
@@ -933,13 +932,11 @@ exports[`printWidth 1`] = `
 "/**
  * A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A
  * A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A
- * A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A
- * A
+ * A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A
  *
  * A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A
  * A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A
- * A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A
- * A
+ * A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A
  */
 "
 `;

--- a/tests/__snapshots__/files/prism-core.js.shot
+++ b/tests/__snapshots__/files/prism-core.js.shot
@@ -513,8 +513,8 @@ var Prism = (function (_self) {
 		 *   [disabled by default](https://prismjs.com/faq.html#why-is-asynchronous-highlighting-disabled-by-default).
 		 *
 		 *   Note: All language definitions required to highlight the code must be included in the main \`prism.js\` file for
-		 *   asynchronous highlighting to work. You can build your own bundle on the [Download
-		 *   page](https://prismjs.com/download.html). Default is \`false\`
+		 *   asynchronous highlighting to work. You can build your own bundle on the
+		 *   [Download page](https://prismjs.com/download.html). Default is \`false\`
 		 * @param {HighlightCallback} [callback] An optional callback to be invoked after the highlighting is done. Mostly
 		 *   useful when \`async\` is \`true\`, since in that case, the highlighting is done asynchronously.
 		 * @public

--- a/tests/__snapshots__/files/tsdoc.ts.shot
+++ b/tests/__snapshots__/files/tsdoc.ts.shot
@@ -110,5 +110,11 @@ interface DialogProps {
    */
   modal?: boolean;
 }
+
+/**
+ * Tsdoc doesn't support backticks spanning multiple lines \`this should not break the line like never ever, ever, ever, ever, ever, ever, ever, ever, ever, ever\`
+ * and then even more \`of these\`
+ */
+function noop() {}
 "
 `;

--- a/tests/__snapshots__/files/tsdoc.ts.shot
+++ b/tests/__snapshots__/files/tsdoc.ts.shot
@@ -112,7 +112,8 @@ interface DialogProps {
 }
 
 /**
- * Tsdoc doesn't support backticks spanning multiple lines \`this should not break the line like never ever, ever, ever, ever, ever, ever, ever, ever, ever, ever\`
+ * Tsdoc doesn't support backticks spanning multiple lines
+ * \`this should not break the line like never ever, ever, ever, ever, ever, ever, ever, ever, ever, ever\`,
  * and then even more \`of these\`
  */
 function noop() {}

--- a/tests/__snapshots__/main.test.ts.snap
+++ b/tests/__snapshots__/main.test.ts.snap
@@ -130,9 +130,8 @@ exports[`Long description memory leak 1`] = `
  * https://example.com
  *
  * @param {LogLevel | string | ILogger} logging A
- *   {@link @microsoft/signalr.LogLevel}, a string representing a LogLevel, or
- *   an object implementing the {@link @microsoft/signalr.ILogger} interface.
- *   See
+ *   {@link @microsoft/signalr.LogLevel}, a string representing a LogLevel, or an
+ *   object implementing the {@link @microsoft/signalr.ILogger} interface. See
  *   {@link https://docs.microsoft.com/aspnet/core/signalr/configuration#configure-logging|the documentation for client logging configuration}
  *   for more details.
  * @returns The {@link @microsoft/signalr.HubConnectionBuilder} instance, for

--- a/tests/files/tsdoc.ts
+++ b/tests/files/tsdoc.ts
@@ -105,3 +105,8 @@ export function add(x: number, y: number): number {
      */
     modal?: boolean;
   }
+
+/**
+ * tsdoc doesn't support backticks spanning multiple lines \`this should not break the line like never ever, ever, ever, ever, ever, ever, ever, ever, ever, ever\` and then even more \`of these\` 
+ */
+function noop() {}

--- a/tests/files/tsdoc.ts
+++ b/tests/files/tsdoc.ts
@@ -107,6 +107,6 @@ export function add(x: number, y: number): number {
   }
 
 /**
- * tsdoc doesn't support backticks spanning multiple lines \`this should not break the line like never ever, ever, ever, ever, ever, ever, ever, ever, ever, ever\` and then even more \`of these\` 
+ * tsdoc doesn't support backticks spanning multiple lines \`this should not break the line like never ever, ever, ever, ever, ever, ever, ever, ever, ever, ever\`, and then even more \`of these\` 
  */
 function noop() {}


### PR DESCRIPTION
I noticed that the plugin can break paragraphs by splitting inline code block (``) into multiple lines. This breaks tsdoc parser (I am not sure sure about jsdoc).

I also took liberty of improving the output for build script. 