### PR TITLE
chore: export Options to better assist type checking for .prettierrc.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,6 +233,7 @@ function mergeParsers(originalParser: prettier.Parser, parserName: string) {
 }
 
 export { options, parsers, defaultOptions };
+export type Options = Partial<JsdocOptions>;
 
 function normalizeOptions(options: prettier.ParserOptions & JsdocOptions) {
   if (options.jsdocCommentLineStrategy) {


### PR DESCRIPTION
This change enables developers to import the Options type in their .prettierrc.js file to assist them in making type checking on Options.

For example,

```ts
// import prettier-plugin-jsdoc Options

/** @type {import('prettier-plugin-jsdoc').Options} } */
const prettierPluginJsdocOptions = {
  jsdocCapitalizeDescription: false,
}

// import prettier Options

/** @type {import('prettier').Options} */
const config = {
  plugins: ['prettier-plugin-jsdoc'],
  ...prettierPluginJsdocOptions,
  singleAttributePerLine: true,
  arrowParens: 'always',
}
```

![CleanShot 2023-10-07 at 12 31 02](https://github.com/hosseinmd/prettier-plugin-jsdoc/assets/1500206/5ca00379-b98d-41dd-9ce8-a62140f26c79)
