### PR TITLE
fix: provide correct types path in conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },


### PR DESCRIPTION
I missed it somehow in https://github.com/hosseinmd/prettier-plugin-jsdoc/pull/195

When working in TypeScript project with `moduleResolution` set to `node16`, `nodenext`, or `bundler`, it's impossible to import type `Options` from the package, because its types are resolved to `./dist/types`

https://github.com/hosseinmd/prettier-plugin-jsdoc/blob/a774106d68d4ebfce332059e46321fdecc490591/src/index.ts#L240