### PR TITLE
Fixed duplication of "Default is ..." in documentation comments.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -539,7 +539,7 @@ function addDefaultValueToDescription(tag: Spec): Spec {
     let { description } = tag;
 
     // remove old note
-    description = description.replace(/[\s]*Default[\s]*is[\s]*`.*`\.?$/, "");
+    description = description.replace(/(?:\s*Default\s+is\s+`.*?`\.?)+/g, "");
 
     // add a `.` at the end of previous sentences
     if (description && !/[.\n]$/.test(description)) {


### PR DESCRIPTION
The function `addDefaultValueToDescription` was appending multiple "Default is ..." notes to the description upon repeated invocations. This issue has been resolved by updating the regular expression to remove all existing occurrences of "Default is ..." before appending the new default value note.