### PR TITLE
fix: add compatibility with prettier v3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jest": "^29.6.4",
     "jest-light-runner": "^0.5.0",
     "jest-specific-snapshot": "^5.0.0",
-    "prettier": "^3.0.3",
+    "prettier": "^3.6.1",
     "rollup": "^2.70.1",
     "standard-version": "^9.3.2",
     "terser": "^5.12.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,17 +56,14 @@ const options = {
     type: "choice",
     choices: [
       {
-        since: "1.1.0",
         value: "singleLine",
         description: `Should compact single line comment, if possible`,
       },
       {
-        since: "1.1.0",
         value: "multiline",
         description: `Should compact multi line comment`,
       },
       {
-        since: "1.1.0",
         value: "keep",
         description: `Should keep original line comment`,
       },
@@ -130,7 +127,6 @@ const options = {
     type: "choice",
     choices: [
       {
-        since: "0.3.39",
         value: "greedy",
         description: `Lines wrap as soon as they reach the print width`,
       },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -56,7 +56,9 @@ export const getParser = (originalParse: Parser["parse"], parserName: string) =>
     await Promise.all(
       ast.comments.map(async (comment) => {
         if (!isBlockComment(comment)) return;
-        const tokenIndex = findTokenIndex(ast.tokens, comment);
+        const tokenIndex = ast.tokens
+          ? findTokenIndex(ast.tokens, comment)
+          : -1;
         const paramsOrder = getParamsOrders(ast, tokenIndex);
         const originalValue = comment.value;
 
@@ -460,6 +462,10 @@ function getParamsOrders(ast: AST, tokenIndex: number): string[] | undefined {
   let params: Token[] | undefined;
 
   try {
+    if (tokenIndex === -1 || !Array.isArray(ast.tokens)) {
+      return undefined;
+    }
+
     // next token
     const nextTokenType = ast.tokens[tokenIndex + 1]?.type;
     if (typeof nextTokenType !== "object") {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,7 +4,6 @@ import {
   convertToModernType,
   formatType,
   detectEndOfLine,
-  findTokenIndex,
   findPluginByParser,
   isDefaultTag,
 } from "./utils.js";
@@ -19,7 +18,7 @@ import {
   TAGS_TYPELESS,
   TAGS_VERTICALLY_ALIGN_ABLE,
 } from "./roles.js";
-import { AST, AllOptions, PrettierComment, Token } from "./types.js";
+import { AST, AllOptions, PrettierComment } from "./types.js";
 import { stringify } from "./stringify.js";
 import { Parser } from "prettier";
 import { SPACE_TAG_DATA } from "./tags.js";
@@ -56,10 +55,8 @@ export const getParser = (originalParse: Parser["parse"], parserName: string) =>
     await Promise.all(
       ast.comments.map(async (comment) => {
         if (!isBlockComment(comment)) return;
-        const tokenIndex = ast.tokens
-          ? findTokenIndex(ast.tokens, comment)
-          : -1;
-        const paramsOrder = getParamsOrders(ast, tokenIndex);
+
+        const paramsOrder = getParamsOrders(text, comment);
         const originalValue = comment.value;
 
         /** Issue: https://github.com/hosseinmd/prettier-plugin-jsdoc/issues/18 */
@@ -456,81 +453,83 @@ function convertCommentDescToDescTag(parsed: Block): void {
 }
 
 /**
- * This is for find params of function name in code as strings of array
+ * This is for find params of function name in code as strings of array. Since
+ * tokens are not available in newer Prettier versions, we'll parse the text
+ * directly.
  */
-function getParamsOrders(ast: AST, tokenIndex: number): string[] | undefined {
-  let params: Token[] | undefined;
-
+function getParamsOrders(
+  text: string,
+  comment: PrettierComment,
+): string[] | undefined {
   try {
-    if (tokenIndex === -1 || !Array.isArray(ast.tokens)) {
-      return undefined;
+    const lines = text.split("\n");
+    let commentEnd = 0;
+    for (let i = 0; i < comment.loc.end.line - 1; i++) {
+      commentEnd += lines[i].length + 1;
+    }
+    commentEnd += comment.loc.end.column;
+
+    const textAfterComment = text.slice(commentEnd);
+
+    const functionMatch = textAfterComment.match(
+      /^\s*function\s+\w*\s*\(([^)]*)\)/,
+    );
+    if (functionMatch) {
+      const paramsString = functionMatch[1];
+      const params = paramsString
+        .split(",")
+        .map((param) => {
+          const trimmed = param.trim();
+          const colonIndex = trimmed.indexOf(":");
+          const paramName =
+            colonIndex > -1 ? trimmed.slice(0, colonIndex) : trimmed;
+          return paramName.split(/\s+/)[0].replace(/[{}[\]]/g, "");
+        })
+        .filter((param) => param && param !== "...");
+
+      return params;
     }
 
-    // next token
-    const nextTokenType = ast.tokens[tokenIndex + 1]?.type;
-    if (typeof nextTokenType !== "object") {
-      return undefined;
-    }
-    // Recognize function
-    if (nextTokenType.label === "function") {
-      let openedParenthesesCount = 1;
-      const tokensAfterComment = ast.tokens.slice(tokenIndex + 4);
+    const arrowMatch = textAfterComment.match(
+      /^\s*(?:const|let|var)\s+\w+\s*=\s*\(([^)]*)\)\s*=>/,
+    );
+    if (arrowMatch) {
+      const paramsString = arrowMatch[1];
+      const params = paramsString
+        .split(",")
+        .map((param) => {
+          const trimmed = param.trim();
+          const colonIndex = trimmed.indexOf(":");
+          const paramName =
+            colonIndex > -1 ? trimmed.slice(0, colonIndex) : trimmed;
+          return paramName.split(/\s+/)[0].replace(/[{}[\]]/g, "");
+        })
+        .filter((param) => param && param !== "...");
 
-      const endIndex = tokensAfterComment.findIndex(({ type }) => {
-        if (typeof type === "string") {
-          return false;
-        } else if (type.label === "(") {
-          openedParenthesesCount++;
-        } else if (type.label === ")") {
-          openedParenthesesCount--;
-        }
-
-        return openedParenthesesCount === 0;
-      });
-
-      params = tokensAfterComment.slice(0, endIndex + 1);
+      return params;
     }
 
-    // Recognize arrow function
-    if (nextTokenType.label === "const") {
-      let openedParenthesesCount = 1;
-      let tokensAfterComment = ast.tokens.slice(tokenIndex + 1);
-      const firstParenthesesIndex = tokensAfterComment.findIndex(
-        ({ type }) => typeof type === "object" && type.label === "(",
-      );
+    const methodMatch = textAfterComment.match(/^\s*(\w+)\s*\(([^)]*)\)/);
+    if (methodMatch) {
+      const paramsString = methodMatch[2];
+      const params = paramsString
+        .split(",")
+        .map((param) => {
+          const trimmed = param.trim();
+          const colonIndex = trimmed.indexOf(":");
+          const paramName =
+            colonIndex > -1 ? trimmed.slice(0, colonIndex) : trimmed;
+          return paramName.split(/\s+/)[0].replace(/[{}[\]]/g, "");
+        })
+        .filter((param) => param && param !== "...");
 
-      tokensAfterComment = tokensAfterComment.slice(firstParenthesesIndex + 1);
-
-      const endIndex = tokensAfterComment.findIndex(({ type }) => {
-        if (typeof type === "string") {
-          return false;
-        } else if (type.label === "(") {
-          openedParenthesesCount++;
-        } else if (type.label === ")") {
-          openedParenthesesCount--;
-        }
-
-        return openedParenthesesCount === 0;
-      });
-
-      const arrowItem: Token | undefined = tokensAfterComment[endIndex + 1];
-
-      if (
-        typeof arrowItem?.type === "object" &&
-        arrowItem.type.label === "=>"
-      ) {
-        params = tokensAfterComment.slice(0, endIndex + 1);
-      }
+      return params;
     }
 
-    return params
-      ?.filter(({ type }) => typeof type === "object" && type.label === "name")
-      .map(({ value }) => value);
-  } catch {
-    //
+    return undefined;
+  } catch (error) {
+    return undefined;
   }
-
-  return;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -280,10 +280,12 @@ const findPluginByParser = (parserName: string, options: ParserOptions) => {
   const tsPlugin = options.plugins.find((plugin) => {
     return (
       typeof plugin === "object" &&
+      plugin !== null &&
+      !(plugin instanceof URL) &&
       (plugin as any).name &&
-      plugin.parsers &&
+      (plugin as any).parsers &&
       // eslint-disable-next-line no-prototype-builtins
-      plugin.parsers.hasOwnProperty(parserName)
+      (plugin as any).parsers.hasOwnProperty(parserName)
     );
   }) as Plugin | undefined;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,6 +209,9 @@ function detectEndOfLine(text: string): "cr" | "crlf" | "lf" {
  * @param token
  */
 function findTokenIndex(tokens: Token[], token: Token): number {
+  if (!Array.isArray(tokens) || tokens.length === 0) {
+    return -1;
+  }
   return BSearch.eq(tokens, token, (a, b) => {
     if (a.loc.start.line === b.loc.start.line) {
       return a.loc.start.column - b.loc.start.column;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4733,10 +4733,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz"
-  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+prettier@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.1.tgz#cc3bce21c09a477b1e987b76ce9663925d86ae44"
+  integrity sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==
 
 pretty-format@^27.3.1:
   version "27.3.1"


### PR DESCRIPTION
Closes #245.

Plugin crashes with `TypeError: Cannot read properties of undefined (reading 'length')` when using Prettier 3.6.0 due to changes in the AST structure where `ast.tokens` can be `undefined`.

Added defensive checks in two places:

- `parser.ts`: Check if `ast.tokens` exists before calling `findTokenIndex`
- `utils.ts`: Add null/undefined guards in `findTokenIndex` function
- `getParamsOrders`: Handle case when `tokenIndex` is -1
