### PR TITLE
test: prettier version bump into 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [16.x, 18.x, 20.x]
-        prettier: ["3.6"]
+        prettier: ["3.0", "3.6"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [16.x, 18.x, 20.x]
-        prettier: ["3.0"]
+        prettier: ["3.6"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm i -g yarn
       - name: Install project dependencies
         run: yarn install
-      - name: Install specific yarn version
+      - name: Install specific prettier version
         run: yarn add prettier@${{ matrix.prettier }} && yarn list --depth=0 --pattern "prettier"
       - name: Run tests
         run: yarn test

--- a/tests/__snapshots__/files/prism-core.js.shot
+++ b/tests/__snapshots__/files/prism-core.js.shot
@@ -3,13 +3,6 @@
 exports[`File: prism-core.js 1`] = `
 "/// <reference lib=\\"WebWorker\\"/>
 
-var _self =
-	typeof window !== 'undefined'
-		? window // if in browser
-		: typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope
-			? self // if in worker
-			: {}; // if in node js
-
 /**
  * Prism: Lightweight, robust, elegant syntax highlighting
  *

--- a/tests/files/prism-core.js
+++ b/tests/files/prism-core.js
@@ -1,13 +1,5 @@
 /// <reference lib="WebWorker"/>
 
-var _self = (typeof window !== 'undefined')
-	? window   // if in browser
-	: (
-		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
-		? self // if in worker
-		: {}   // if in node js
-	);
-
 /**
  * Prism: Lightweight, robust, elegant syntax highlighting
  *


### PR DESCRIPTION
Prettier 3.6 has some rule changes, updated the test flow to match the version.

https://prettier.io/blog/2025/06/23/3.6.0#other-changes

Note: Needs approval for running tests on Github actions.