### PR TITLE
chore(ci): update nodejs test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16.x, 18.x, 20.x]
+        node: [20.x, 22.x, 24.x]
         prettier: ["3.0", "3.6"]
 
     steps:


### PR DESCRIPTION
update nodejs github workflow testing matrix to support newer nodejs versions and drop support for old nodejs versions.