### PR TITLE
feat: add jsdocContinuationLineSpaces option for wrapped tag lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Like code tags (` ```js `), header tags like `# Header`, or other Markdown featu
 | Key                                 | Type                              | Default      | Description                                                                                                                                                             |
 | :---------------------------------- | :-------------------------------- | :----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `jsdocSpaces`                       | Number                            | 1            |
+| `jsdocContinuationLineSpaces`       | Number                            | 2            | How many spaces to indent continuing tag description lines                                                                                                               |
 | `jsdocDescriptionWithDot`           | Boolean                           | false        |
 | `jsdocDescriptionTag`               | Boolean                           | false        |
 | `jsdocVerticalAlignment`            | Boolean                           | false        |

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,13 @@ const options = {
     default: 1,
     description: "How many spaces will be used to separate tag elements.",
   },
+  jsdocContinuationLineSpaces: {
+    name: "jsdocContinuationLineSpaces",
+    type: "int",
+    category: "jsdoc",
+    default: 2,
+    description: "How many spaces will be used to indent continuing tag lines.",
+  },
   jsdocDescriptionWithDot: {
     name: "jsdocDescriptionWithDot",
     type: "boolean",
@@ -204,6 +211,7 @@ const options = {
 
 const defaultOptions: JsdocOptions = {
   jsdocSpaces: options.jsdocSpaces.default,
+  jsdocContinuationLineSpaces: options.jsdocContinuationLineSpaces.default,
   jsdocPrintWidth: options.jsdocPrintWidth.default,
   jsdocDescriptionWithDot: options.jsdocDescriptionWithDot.default,
   jsdocDescriptionTag: options.jsdocDescriptionTag.default,

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -36,6 +36,7 @@ const stringify = async (
   const {
     printWidth,
     jsdocSpaces,
+    jsdocContinuationLineSpaces,
     jsdocVerticalAlignment,
     jsdocDescriptionTag,
     tsdoc,
@@ -142,7 +143,7 @@ const stringify = async (
         tag === DESCRIPTION ||
         ([EXAMPLE, REMARKS, PRIVATE_REMARKS].includes(tag) && tsdoc)
           ? ""
-          : "  "; // google style guide space
+          : " ".repeat(jsdocContinuationLineSpaces);
 
       if (
         (tag !== DESCRIPTION &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { ParserOptions } from "prettier";
 
 export interface JsdocOptions {
   jsdocSpaces: number;
+  jsdocContinuationLineSpaces: number;
   jsdocPrintWidth?: number;
   jsdocDescriptionWithDot: boolean;
   jsdocDescriptionTag: boolean;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -322,6 +322,30 @@ test("Should insert proper amount of spaces based on option", async () => {
   expect(Result2).toMatchSnapshot();
 });
 
+test("Should indent continuing tag lines based on jsdocContinuationLineSpaces", async () => {
+  const result = await subject(
+    `/**
+ * Retrieves the item rewards for specific streak milestones.
+ *
+ * @param streak The current streak count.
+ * @returns An array of item IDs awarded for the streak, or an empty array if no items are awarded for the given streak.
+ */`,
+    {
+      printWidth: 90,
+      jsdocContinuationLineSpaces: 4,
+    },
+  );
+
+  expect(result).toEqual(`/**
+ * Retrieves the item rewards for specific streak milestones.
+ *
+ * @param streak The current streak count.
+ * @returns An array of item IDs awarded for the streak, or an empty array if no
+ *     items are awarded for the given streak.
+ */
+`);
+});
+
 test("yields should work like returns tag", async () => {
   const options = {
     jsdocSpaces: 3,


### PR DESCRIPTION
## Summary

Adds a new `jsdocContinuationLineSpaces` option to control indentation for wrapped JSDoc tag description lines.

Previously, continuation lines for tags like @returns used a hardcoded two-space indent. This change makes that spacing configurable, with a default of `2`, while preserving existing behavior unless the option is set.

## Changes

- Added `jsdocContinuationLineSpaces` to the plugin option schema
- Added the option to `JsdocOptions` and `defaultOptions`
- Replaced the hardcoded continuation indent in tag description wrapping with the new option
- Added a focused test covering non-default continuation indentation
- Documented the new option in the README

## Example

Input:

```
  /**
   * @returns An array of item IDs awarded for the streak, or an empty array if no items are awarded for the given streak.
   */
```

By default, `jsdocContinuationLineSpaces` is `2` (same as original):

```
  /**
   * @returns An array of item IDs awarded for the streak, or an empty array if no
   *   items are awarded for the given streak.
   */
```

With `jsdocContinuationLineSpaces` set to `4`:

```
  /**
   * @returns An array of item IDs awarded for the streak, or an empty array if no
   *     items are awarded for the given streak.
   */
```

## Notes

Default behavior is unchanged:

- jsdocContinuationLineSpaces defaults to `2`
- existing users should see no formatting difference unless they opt in to another value

## Testing

- Added a unit test for wrapped tag descriptions using a non-default `jsdocContinuationLineSpaces` value